### PR TITLE
Restoring profession trainers in cities

### DIFF
--- a/sql/world/base/zone_darnassus.sql
+++ b/sql/world/base/zone_darnassus.sql
@@ -1,3 +1,95 @@
 -- Dannelor <First Aid Trainer>
 DELETE FROM `npc_trainer` WHERE `ID`=4211; 
 INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (4211, -350000); 
+
+-- Milla Fairancora <Journeyman Alchemist>
+UPDATE `creature_template` SET `subname`='Journeyman Alchemist', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11041;
+
+-- Sylvanna Forestmoon <Expert Alchemist>
+UPDATE `creature_template` SET `subname`='Expert Alchemist', `npcflag`=81, `trainer_type`=2, `type_flags`=134217728 WHERE `entry`=11042;
+
+-- Lalina Summermoon <Journeyman Enchanter>
+UPDATE `creature_template` SET `subname`='Journeyman Enchanter', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11070;
+
+-- Darianna <Journeyman Leatherworker>
+UPDATE `creature_template` SET `subname`='Journeyman Leatherworker', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11083;
+
+-- Faldron <Expert Leatherworker>
+UPDATE `creature_template` SET `subname`='Journeyman Leatherworker', `npcflag`=81, `trainer_type`=2, `type_flags`=134217728 WHERE `entry`=11081;
+
+-- Telonis <Artisan Leatherworker>
+UPDATE `creature_template` SET `type_flags`=134217728 WHERE `entry`=4212;
+
+-- Trianna <Journeyman Tailor>
+UPDATE `creature_template` SET `subname`='Journeyman Tailor', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11050;
+
+
+-- Milla Fairancora <Journeyman Alchemist>
+DELETE FROM `npc_trainer` WHERE `ID`=11041;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11041, -300000);
+
+-- Sylvanna Forestmoon <Expert Alchemist>
+DELETE FROM `npc_trainer` WHERE `ID`=11042;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11042, -300000), (11042, -300001);
+
+-- Lalina Summermoon <Journeyman Enchanter>
+DELETE FROM `npc_trainer` WHERE `ID`=11070;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11070, -330000);
+
+-- Trianna <Journeyman Tailor>
+DELETE FROM `npc_trainer` WHERE `ID`=11050;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11050, -410000);
+
+-- Darianna <Journeyman Leatherworker>
+DELETE FROM `npc_trainer` WHERE `ID`=11083;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11083, -380000);
+
+-- Faldron <Expert Leatherworker>
+DELETE FROM `npc_trainer` WHERE `ID`=11081;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11081, -380000), (11081, -380001);
+
+-- Sylvanna Forestmoon <Expert Alchemist>
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=4125;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES 
+(4125, 0, 3, 'Train me.', 3266, 5, 16);
+
+-- Faldron <Expert Leatherworker>
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=4204;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES 
+(4204, 0, 3, 'Train me.', 3266, 5, 16);
+
+-- Telonis <Artisan Leatherworker>
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=4241;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES 
+(4241, 0, 3, 'Train me.', 3266, 5, 16);
+
+
+-- Sylvanna Forestmoon <Expert Alchemist>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4125 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 4125, 0, 7, 171, 50, 'Show menu if alchemy is 50 or higher');
+
+-- Ainethil <Artisan Alchemist>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4131 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 4131, 0, 7, 171, 125, 'Show menu if alchemy is 125 or higher');
+
+-- Taladan <Expert Enchanter>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4163 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES 
+(15, 4163, 0, 7, 333, 50, 'Show menu if enchanting is 50 or higher');
+
+-- Faldron <Expert Leatherworker>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4204 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 4204, 0, 7, 165, 50, 'Show menu if leatherworking is 50 or higher');
+
+-- Telonis <Artisan Leatherworker>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4241 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 4241, 0, 7, 165, 125, 'Show menu if leatherworking is 125 or higher');
+
+-- Me'lynn <Expert Tailor>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4349 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES 
+(15, 4349, 0, 7, 197, 50, 'Show menu if tailoring is 50 or higher');

--- a/sql/world/base/zone_darnassus.sql
+++ b/sql/world/base/zone_darnassus.sql
@@ -1,7 +1,3 @@
--- Dannelor <First Aid Trainer>
-DELETE FROM `npc_trainer` WHERE `ID`=4211; 
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (4211, -350000); 
-
 -- Milla Fairancora <Journeyman Alchemist>
 UPDATE `creature_template` SET `subname`='Journeyman Alchemist', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11041;
 
@@ -93,3 +89,8 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4349 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES 
 (15, 4349, 0, 7, 197, 50, 'Show menu if tailoring is 50 or higher');
+
+
+-- Dannelor <First Aid Trainer>
+DELETE FROM `npc_trainer` WHERE `ID`=4211; 
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (4211, -350000); 

--- a/sql/world/base/zone_ironforge.sql
+++ b/sql/world/base/zone_ironforge.sql
@@ -1,11 +1,3 @@
--- Summon Felsteed (Warlock)
-DELETE FROM `creature_queststarter` WHERE `id`=5172 AND `quest`=4487;
-INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (5172, 4487);
-
--- Nissa Firestone <First Aid Trainer> 
-DELETE FROM `npc_trainer` WHERE `ID`=5150; 
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5150, -350000); 
-
 -- Vosur Brakthel <Journeyman Alchemist>
 UPDATE `creature_template` SET `subname`='Journeyman Alchemist', `npcflag`=81, `trainer_type`=2 WHERE `entry`=1246;
 
@@ -121,3 +113,12 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4345 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES 
 (15, 4345, 0, 7, 197, 50, 'Show menu if tailoring is 50 or higher');
+
+
+-- Summon Felsteed (Warlock)
+DELETE FROM `creature_queststarter` WHERE `id`=5172 AND `quest`=4487;
+INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (5172, 4487);
+
+-- Nissa Firestone <First Aid Trainer> 
+DELETE FROM `npc_trainer` WHERE `ID`=5150; 
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5150, -350000); 

--- a/sql/world/base/zone_ironforge.sql
+++ b/sql/world/base/zone_ironforge.sql
@@ -5,3 +5,119 @@ INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (5172, 4487);
 -- Nissa Firestone <First Aid Trainer> 
 DELETE FROM `npc_trainer` WHERE `ID`=5150; 
 INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5150, -350000); 
+
+-- Vosur Brakthel <Journeyman Alchemist>
+UPDATE `creature_template` SET `subname`='Journeyman Alchemist', `npcflag`=81, `trainer_type`=2 WHERE `entry`=1246;
+
+-- Groum Stonebeard <Journeyman Blacksmith>
+UPDATE `creature_template` SET `subname`='Journeyman Blacksmith', `npcflag`=81, `trainer_type`=2 WHERE `entry`=10277;
+
+-- Rotgath Stonebeard <Expert Blacksmith>
+UPDATE `creature_template` SET `subname`='Expert Blacksmith', `npcflag`=81, `trainer_type`=2, `type_flags`=134217728 WHERE `entry`=10276;
+
+-- Thonys Pillarstone <Journeyman Enchanter>
+UPDATE `creature_template` SET `subname`='Journeyman Enchanter', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11065;
+
+-- Gimble Thistlefuzz <Expert Enchanter>
+UPDATE `creature_template` SET `type_flags`=134217728 WHERE `entry`=5157;
+
+-- Jemma Quikswitch <Journeyman Engineer>
+UPDATE `creature_template` SET `subname`='Journeyman Engineer', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11028;
+
+-- Trixie Quikswitch <Expert Engineer>
+UPDATE `creature_template` SET `subname`='Journeyman Engineer', `npcflag`=81, `trainer_type`=2, `type_flags`=134217728 WHERE `entry`=11029;
+
+-- Gretta Finespindle <Journeyman Leatherworker>
+UPDATE `creature_template` SET `subname`='Journeyman Leatherworker', `npcflag`=81, `trainer_type`=2 WHERE `entry`=1466;
+
+-- Uthrar Threx <Journeyman Tailor>
+UPDATE `creature_template` SET `subname`='Journeyman Tailor', `npcflag`=81, `trainer_type`=2 WHERE `entry`=1703;
+
+
+-- Vosur Brakthel <Journeyman Alchemist>
+DELETE FROM `npc_trainer` WHERE `ID`=1246;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (1246, -300000);
+
+-- Groum Stonebeard <Journeyman Blacksmith>
+DELETE FROM `npc_trainer` WHERE `ID`=10277;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (10277, -310000);
+
+-- Rotgath Stonebeard <Expert Blacksmith>
+DELETE FROM `npc_trainer` WHERE `ID`=10276;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (10276, -310000), (10276, -310001);
+
+-- Thonys Pillarstone <Journeyman Enchanter>
+DELETE FROM `npc_trainer` WHERE `ID`=11065;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11065, -330000);
+
+-- Jemma Quikswitch <Journeyman Engineer>
+DELETE FROM `npc_trainer` WHERE `ID`=11028;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11028, -340000);
+
+-- Trixie Quikswitch <Expert Engineer>
+DELETE FROM `npc_trainer` WHERE `ID`=11029;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11029, -340000), (11029, -340001);
+
+-- Gretta Finespindle <Journeyman Leatherworker>
+DELETE FROM `npc_trainer` WHERE `ID`=1466;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (1466, -380000);
+
+-- Uthrar Threx <Journeyman Tailor>
+DELETE FROM `npc_trainer` WHERE `ID`=1703;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (1703, -410000);
+
+-- Rotgath Stonebeard <Expert Blacksmith>
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=2761;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES 
+(2761, 0, 3, 'Train me.', 3266, 5, 16);
+
+-- Gimble Thistlefuzz <Expert Enchanter>
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=4160;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES 
+(4160, 0, 3, 'Train me.', 3266, 5, 16);
+
+-- Trixie Quikswitch <Expert Engineer>
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=4147;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES
+(4147, 0, 3, 'Train me.', 3266, 5, 16);
+
+
+-- Tally Berryfizz <Expert Alchemist>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4123 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 4123, 0, 7, 171, 50, 'Show menu if alchemy is 50 or higher');
+
+-- Rotgath Stonebeard <Expert Blacksmith>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=2761 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 2761, 0, 7, 164, 50, 'Show menu if blacksmithing is 50 or higher');
+
+-- Bengus Deepforge <Artisan Blacksmith>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=593 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 593, 0, 7, 164, 125, 'Show menu if blacksmithing is 125 or higher');
+
+-- Gimble Thistlefuzz <Expert Enchanter>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4160 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES 
+(15, 4160, 0, 7, 333, 50, 'Show menu if enchanting is 50 or higher');
+
+-- Trixie Quikswitch <Expert Engineer>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4147 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 4147, 0, 7, 202, 50, 'Show menu if engineering is 50 or higher');
+
+-- Springspindle Fizzlegear <Artisan Engineer>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4150 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 4150, 0, 7, 202, 125, 'Show menu if engineering is 125 or higher');
+
+-- Fimble Finespindle <Expert Leatherworker>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4205 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES 
+(15, 4205, 0, 7, 165, 50, 'Show menu if leatherworking is 50 or higher');
+
+-- Jormund Stonebrow <Expert Tailor>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4345 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES 
+(15, 4345, 0, 7, 197, 50, 'Show menu if tailoring is 50 or higher');

--- a/sql/world/base/zone_orgrimmar.sql
+++ b/sql/world/base/zone_orgrimmar.sql
@@ -412,10 +412,11 @@ DELETE FROM `npc_vendor` WHERE `entry`=3366 AND `item`=38426;
 -- Felika <General Trade Goods Merchant>
 DELETE FROM `npc_vendor` WHERE `entry`=3367 AND `item` IN (14341, 18256, 20856);
 DELETE FROM `npc_vendor` WHERE `entry`=3367 AND `item` IN (2324, 2605, 6260, 6529);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (3367, 2324);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (3367, 2605);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (3367, 6260);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (3367, 6529);
+INSERT INTO `npc_vendor` (`entry`, `item`) VALUES
+    (3367, 2324), 
+    (3367, 2605), 
+    (3367, 6260), 
+    (3367, 6529);
 
 -- Borstan <Meat Vendor>
 DELETE FROM `npc_vendor` WHERE `entry`=3368 AND `item` IN (27854, 33454, 35953);
@@ -487,7 +488,7 @@ DELETE FROM `npc_vendor` WHERE `entry`=12794 AND `item` IN
 
 INSERT INTO `npc_vendor` (`entry`, `item`) VALUES
     (12794, 117), (12794, 159), (12794, 1179), (12794, 1205), (12794, 1645), (12794, 1708), (12794, 2287), (12794, 2593), (12794, 2594), (12794, 2595), (12794, 2596), (12794, 2723),
-    (12794, 3770), (12794, 3771), (12794, 4536), (12794, 4537), (12794, 4538), (12794, 4539), (12794, 4540), (12794, 4541), (12794, 4542), (12794, 4544), (12794, 4599), (12794, 4601);
+    (12794, 3770), (12794, 3771), (12794, 4536), (12794, 4537), (12794, 4538), (12794, 4539), (12794, 4540), (12794, 4541), (12794, 4542), (12794, 4544), (12794, 4599), (12794, 4601),
     (12794, 4602), (12794, 4604), (12794, 4605), (12794, 4606), (12794, 4607), (12794, 4608), (12794, 8766), (12794, 8948), (12794, 8950), (12794, 8952), (12794, 8953);
 
 -- Raider Bork <Mount Quartermaster>

--- a/sql/world/base/zone_orgrimmar.sql
+++ b/sql/world/base/zone_orgrimmar.sql
@@ -1,184 +1,8 @@
--- Saru Steelfury <Artisan Blacksmith>
-DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=1012 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES (15, 1012, 0, 7, 164, 125, 'Show menu if blacksmithing is 125 or higher');
-
--- Snarl <Expert Blacksmith>
-DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=2782 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES (15, 2782, 0, 7, 164, 50, 'Show menu if blacksmithing is 50 or higher');
-
--- Yelmak <Expert Alchemist>
-DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4126 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES (15, 4126, 0, 7, 171, 50, 'Show menu if alchemy is 50 or higher');
-
--- Nogg <Expert Engineer>
-DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4148 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES (15, 4148, 0, 7, 202, 50, 'Show menu if engineering is 50 or higher');
-
--- Roxxik <Artisan Engineer>
-DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4151 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES (15, 4151, 0, 7, 202, 125, 'Show menu if engineering is 125 or higher');
-
--- Godan <Expert Enchanter>
-DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4168 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES (15, 4168, 0, 7, 333, 50, 'Show menu if enchanting is 50 or higher');
-
--- Karolek <Expert Leatherworker>
-DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4209 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES (15, 4209, 0, 7, 165, 50, 'Show menu if leatherworking is 50 or higher');
-
--- Magar <Expert Tailor>
-DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4347 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES (15, 4347, 0, 7, 197, 50, 'Show menu if tailoring is 50 or higher');
-
--- Vol'jin <King of Darkspear Trolls>
-UPDATE `creature_template` SET `subname`='King of Darkspear Trolls', `minlevel`=60, `maxlevel`=60 WHERE `entry`=10540;
-
--- Nazgrel <Advisor to Thrall>
-DELETE FROM `creature` WHERE `id1`=3230 AND `map`=1;
-INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (3230, 1, 1938.55, -4133.22, 41.1424, 4.07636, 300);
-
--- Orgrimmar Grunt
-DELETE FROM `creature` WHERE `guid` IN (10299, 203492, 203493, 203494, 203495);
-INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (10299, 3296, 1, 1620.45, -4252.84, 47.5273, 3.7001, 300);
-
--- Brakgul Deathbringer <Warsong Gulch Battlemaster>
-DELETE FROM `creature` WHERE `id1`=3890;
-INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (3890, 1, 1990.64, -4794.13, 56.0472, 3.22013, 300);
-
--- Legionnaire Teena
-DELETE FROM `creature` WHERE `id1`=12788;
-INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (12788, 1, 1651.22, -4213.42, 55.4372, 0.427786, 25);
-
--- Lady Palanseer <Armor Quartermaster>
-DELETE FROM `creature` WHERE `id1`=34043;
-DELETE FROM `creature` WHERE `id1`=12792;
-INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (12792, 1, 1669.78, -4200.1, 56.3815, 3.61023, 180);
-
--- Brave Stonehide <Officer Accessories Quartermaster>
-DELETE FROM `creature` WHERE `id1`=12793;
-INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (12793, 1, 1657.6, -4191.97, 56.383, 4.52365, 180);
-
--- Stone Guard Zarg <Food and Drink>
-DELETE FROM `creature` WHERE `id1`=12794;
-INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (12794, 1, 1641.65, -4197.52, 56.3823, 5.41219, 180);
-
--- First Sergeant Hola'mahi <Reagent Vendor>
-DELETE FROM `creature` WHERE `id1`=12795;
-INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (12795, 1, 1673.9, -4216, 56.3826, 2.93578, 180);
-
--- Raider Bork <Mount Quartermaster>
-DELETE FROM `creature` WHERE `id1`=12796;
-INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (12796, 1, 1674.43, -4212.55, 56.3829, 3.00254, 1290);
-
--- Sergeant Ba'sha <Accessories Quartermaster>
-DELETE FROM `creature` WHERE `id1`=12799;
-INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (12799, 1, 1632.21, -4262.19, 49.027, 3.63029, 430);
-
--- Sergeant Thunderhorn <Weapons Quartermaster>
-DELETE FROM `creature` WHERE `id1`=14581;
-INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (14581, 1, 1644.52, -4195.26, 56.3826, 5.43078, 180);
-
--- High Overlord Saurfang
-DELETE FROM `creature` WHERE `id1`=14720;
-INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (14720, 1, 1565.79, -4395.27, 6.9866, 3.35103, 600);
-
--- Kartra Bloodsnarl <Alterac Valley Battlemaster>
-DELETE FROM `creature` WHERE `id1`=14942;
-INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (14942, 1, 1980.9, -4787.78, 55.8796, 5.13127, 600);
-
--- Deze Snowbane <Arathis Basin Battlemaster>
-DELETE FROM `creature` WHERE `id1`=15006;
-INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (15006, 1, 2002.26, -4796.74, 56.8471, 3.00197, 600);
-
--- Summon Felsteed (Warlock)
-DELETE FROM `creature_queststarter` WHERE `id`=3326 AND `quest`=3631;
-INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (3326, 3631);
-
--- Knowledge of the Orb of Orahil (Warlock)
-DELETE FROM `creature_queststarter` WHERE `id`=3326 AND `quest`=4967;
-INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (3326, 4967);
-
--- An Imp's Request (Warlock)
-DELETE FROM `creature_queststarter` WHERE `id` IN (3324, 3325, 3326, 4564, 5495, 5496) AND `quest`=8419;
-INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (3326, 8419);
-
--- Snarl <Expert Blacksmith>
-UPDATE `creature_template` SET `subname`='Expert Blacksmith', `npcflag`=81, `trainer_type`=2 WHERE `entry`=1383;
-
--- Snang <Journeyman Tailor>
-UPDATE `creature_template` SET `subname`='Journeyman Tailor', `npcflag`=81, `trainer_type`=2 WHERE `entry`=2855;
-
--- Thund <Journeyman Engineer>
-UPDATE `creature_template` SET `subname`='Journeyman Engineer', `npcflag`=81, `trainer_type`=2 WHERE `entry`=2857;
-
--- Nazgrel <Advisor to Thrall>
-UPDATE `creature_template` SET `scale`=0.7, `npcflag`=2, `faction`=29, `gossip_menu_id`=0 WHERE `entry`=3230;
-
--- Orgrimmar Grunt
-UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=3296;
-
--- Doras <Wind Rider Master>
-UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=3310;
-
--- Trak'gen <General Goods Merchant>
-UPDATE `creature_template` SET `subname`='General Goods Merchant' WHERE `entry`=3313;
-
--- Kaja <Guns and Ammo Merchant>
-UPDATE `creature_template` SET `subname`='Guns and Ammo Merchant' WHERE `entry`=3322;
-
--- Horthus <Reagents Vendor>
-UPDATE `creature_template` SET `subname`='Reagents Vendor' WHERE `entry`=3323;
-
--- Rekkul <Poison Vendor>
-UPDATE `creature_template` SET `subname`='Poison Vendor' WHERE `entry`=3334;
-
--- Hagrus <Reagents Vendor>
-UPDATE `creature_template` SET `subname`='Reagents Vendor' WHERE `entry`=3335;
-
--- Godan <Expert Enchanter>
-UPDATE `creature_template` SET `subname`='Expert Enchanter' WHERE `entry`=3345;
+-- Whuut <Journeyman Alchemist>
+UPDATE `creature_template` SET `subname`='Journeyman Alchemist', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11046;
 
 -- Yelmak <Expert Alchemist>
 UPDATE `creature_template` SET `subname`='Expert Alchemist' WHERE `entry`=3347;
-
--- Asoran <General Goods Vendor>
-UPDATE `creature_template` SET `subname`='General Goods Vendor' WHERE `entry`=3350;
-
--- Magenius <Reagents Vendor>
-UPDATE `creature_template` SET `subname`='Reagents Vendor' WHERE `entry`=3351;
-
--- Saru Steelfury <Artisan Blacksmith>
-UPDATE `creature_template` SET `subname`='Artisan Blacksmith' WHERE `entry`=3355;
-
--- Sumi <Blacksmithing Supplier>
-UPDATE `creature_template` SET `subname`='Blacksmithing Supplier' WHERE `entry`=3356;
-
--- Gorina <Mining Supplier>
-UPDATE `creature_template` SET `subname`='Mining Supplier' WHERE `entry`=3358;
-
--- Magar <Expert Tailor>
-UPDATE `creature_template` SET `subname`='Expert Tailor' WHERE `entry`=3363;
-
--- Karolek <Expert Leatherworker>
-UPDATE `creature_template` SET `subname`='Expert Leatherworker' WHERE `entry`=3365;
-
--- Felika <General Trade Goods Merchant>
-UPDATE `creature_template` SET `subname`='General Trade Goods Merchant' WHERE `entry`=3367;
-
--- Xen'to <Cooking Supplier>
-UPDATE `creature_template` SET `subname`='Cooking Supplier' WHERE `entry`=3400;
-
--- Nogg <Expert Engineer>
-UPDATE `creature_template` SET `subname`='Expert Engineer', `npcflag`=81, `trainer_type`=2 WHERE `entry`=3412;
-
--- Thrall <Warchief>
-UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=4949;
-
--- Kamari <Journeyman Leatherworker>
-UPDATE `creature_template` SET `subname`='Journeyman Leatherworker', `npcflag`=81, `trainer_type`=2 WHERE `entry`=5811;
-
--- Shimra <General Trade Goods Merchant>
-UPDATE `creature_template` SET `subname`='General Trade Goods Merchant' WHERE `entry`=5817;
 
 -- Shayis Steelfury <Armor Crafter>
 UPDATE `creature_template` SET `subname`='Armor Crafter' WHERE `entry`=7230;
@@ -189,71 +13,39 @@ UPDATE `creature_template` SET `subname`='Weapon Crafter' WHERE `entry`=7231;
 -- Ug'thok <Journeyman Blacksmith>
 UPDATE `creature_template` SET `subname`='Journeyman Blacksmith', `npcflag`=81, `trainer_type`=2 WHERE `entry`=10266;
 
--- Roxxik <Artisan Engineer>
-UPDATE `creature_template` SET `subname`='Artisan Engineer', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11017;
+-- Snarl <Expert Blacksmith>
+UPDATE `creature_template` SET `subname`='Expert Blacksmith', `npcflag`=81, `trainer_type`=2, `type_flags`=134217728 WHERE `entry`=1383;
 
--- Whuut <Journeyman Alchemist>
-UPDATE `creature_template` SET `subname`='Journeyman Alchemist', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11046;
+-- Saru Steelfury <Artisan Blacksmith>
+UPDATE `creature_template` SET `subname`='Artisan Blacksmith' WHERE `entry`=3355;
 
 -- Jhag <Journeyman Enchanter>
 UPDATE `creature_template` SET `subname`='Journeyman Enchanter', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11066;
 
--- Snurk Bucksquick <Zeppelin Master>
-UPDATE `creature_template` SET `subname`='Zeppelin Master' WHERE `entry`=12136;
+-- Godan <Expert Enchanter>
+UPDATE `creature_template` SET `subname`='Expert Enchanter' WHERE `entry`=3345;
 
--- Legionnaire Teena
-UPDATE `creature_template` SET `subname`=NULL, `npcflag`=0, `faction`=85 WHERE `entry`=12788;
-
--- Lady Palanseer <Armor Quartermaster>
-UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=12792;
-
--- Brave Stonehide <Officer Accessories Quartermaster>
-UPDATE `creature_template` SET `subname`='Officer Accessories Quartermaster' WHERE `entry`=12793;
-
--- First Sergeant Hola'mahi <Reagent Vendor>
-UPDATE `creature_template` SET `subname`='Reagent Vendor' WHERE `entry`=12795;
-
--- Stone Guard Zarg <Food and Drink>
-UPDATE `creature_template` SET `subname`='Food and Drink' WHERE `entry`=12794;
-
--- Raider Bork <Mount Quartermaster>
-UPDATE `creature_template` SET `subname`='Mount Quartermaster' WHERE `entry`=12796;
-
--- Kor'kron Elite
-UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60, `rank`=0 WHERE `entry`=14304;
-
--- Scout Stronghand
-UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14375;
-
--- Scout Manslayer
-UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14376;
-
--- Scout Tharr
-UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14377;
-
--- Sergeant Thunderhorn <Weapons Quartermaster>
-UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=14581;
-
--- High Overlord Saurfang
-UPDATE `creature_template` SET `minlevel`=62, `maxlevel`=62 WHERE `entry`=14720;
-
--- Horde Warbringer
-UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60, `rank`=0 WHERE `entry`=15350;
-
--- Raider Bork <Mount Quartermaster>
-UPDATE `creature_template_addon` SET `mount`=0 WHERE `entry`=12796;
-
--- Snarl <Expert Blacksmith>
-DELETE FROM `gossip_menu_option` WHERE `MenuID`=2782;
-INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES (2782, 0, 3, 'Train me.', 3266, 5, 16);
+-- Thund <Journeyman Engineer>
+UPDATE `creature_template` SET `subname`='Journeyman Engineer', `npcflag`=81, `trainer_type`=2 WHERE `entry`=2857;
 
 -- Nogg <Expert Engineer>
-DELETE FROM `gossip_menu_option` WHERE `MenuID`=4148;
-INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES (4148, 0, 3, 'Train me.', 3266, 5, 16);
+UPDATE `creature_template` SET `subname`='Expert Engineer', `npcflag`=81, `trainer_type`=2, `type_flags`=134217728 WHERE `entry`=3412;
 
 -- Roxxik <Artisan Engineer>
-DELETE FROM `gossip_menu_option` WHERE `MenuID`=4151;
-INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES (4151, 0, 3, 'Train me.', 3266, 5, 16);
+UPDATE `creature_template` SET `subname`='Artisan Engineer', `npcflag`=81, `trainer_type`=2, `type_flags`=134217728 WHERE `entry`=11017;
+
+-- Kamari <Journeyman Leatherworker>
+UPDATE `creature_template` SET `subname`='Journeyman Leatherworker', `npcflag`=81, `trainer_type`=2 WHERE `entry`=5811;
+
+-- Karolek <Expert Leatherworker>
+UPDATE `creature_template` SET `subname`='Expert Leatherworker' WHERE `entry`=3365;
+
+-- Snang <Journeyman Tailor>
+UPDATE `creature_template` SET `subname`='Journeyman Tailor', `npcflag`=81, `trainer_type`=2 WHERE `entry`=2855;
+
+-- Magar <Expert Tailor>
+UPDATE `creature_template` SET `subname`='Expert Tailor' WHERE `entry`=3363;
+
 
 -- Snarl <Expert Blacksmith>
 DELETE FROM `npc_trainer` WHERE `ID`=1383;
@@ -345,6 +137,229 @@ INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11046, -300000);
 DELETE FROM `npc_trainer` WHERE `ID`=11066;
 INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11066, -330000);
 
+
+-- Snarl <Expert Blacksmith>
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=2782;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES
+(2782, 0, 3, 'Train me.', 3266, 5, 16);
+
+-- Nogg <Expert Engineer>
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=4148;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES
+(4148, 0, 3, 'Train me.', 3266, 5, 16);
+
+-- Roxxik <Artisan Engineer>
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=4151;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES
+(4151, 0, 3, 'Train me.', 3266, 5, 16);
+
+
+-- Saru Steelfury <Artisan Blacksmith>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=1012 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 1012, 0, 7, 164, 125, 'Show menu if blacksmithing is 125 or higher');
+
+-- Snarl <Expert Blacksmith>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=2782 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 2782, 0, 7, 164, 50, 'Show menu if blacksmithing is 50 or higher');
+
+-- Yelmak <Expert Alchemist>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4126 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 4126, 0, 7, 171, 50, 'Show menu if alchemy is 50 or higher');
+
+-- Nogg <Expert Engineer>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4148 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 4148, 0, 7, 202, 50, 'Show menu if engineering is 50 or higher');
+
+-- Roxxik <Artisan Engineer>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4151 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 4151, 0, 7, 202, 125, 'Show menu if engineering is 125 or higher');
+
+-- Godan <Expert Enchanter>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4168 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 4168, 0, 7, 333, 50, 'Show menu if enchanting is 50 or higher');
+
+-- Karolek <Expert Leatherworker>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4209 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 4209, 0, 7, 165, 50, 'Show menu if leatherworking is 50 or higher');
+
+-- Magar <Expert Tailor>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4347 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 4347, 0, 7, 197, 50, 'Show menu if tailoring is 50 or higher');
+
+
+-- Nazgrel <Advisor to Thrall>
+DELETE FROM `creature` WHERE `id1`=3230 AND `map`=1;
+INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (3230, 1, 1938.55, -4133.22, 41.1424, 4.07636, 300);
+
+-- Orgrimmar Grunt
+DELETE FROM `creature` WHERE `guid` IN (10299, 203492, 203493, 203494, 203495);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (10299, 3296, 1, 1620.45, -4252.84, 47.5273, 3.7001, 300);
+
+-- Brakgul Deathbringer <Warsong Gulch Battlemaster>
+DELETE FROM `creature` WHERE `id1`=3890;
+INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (3890, 1, 1990.64, -4794.13, 56.0472, 3.22013, 300);
+
+-- Legionnaire Teena
+DELETE FROM `creature` WHERE `id1`=12788;
+INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (12788, 1, 1651.22, -4213.42, 55.4372, 0.427786, 25);
+
+-- Lady Palanseer <Armor Quartermaster>
+DELETE FROM `creature` WHERE `id1`=34043;
+DELETE FROM `creature` WHERE `id1`=12792;
+INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (12792, 1, 1669.78, -4200.1, 56.3815, 3.61023, 180);
+
+-- Brave Stonehide <Officer Accessories Quartermaster>
+DELETE FROM `creature` WHERE `id1`=12793;
+INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (12793, 1, 1657.6, -4191.97, 56.383, 4.52365, 180);
+
+-- Stone Guard Zarg <Food and Drink>
+DELETE FROM `creature` WHERE `id1`=12794;
+INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (12794, 1, 1641.65, -4197.52, 56.3823, 5.41219, 180);
+
+-- First Sergeant Hola'mahi <Reagent Vendor>
+DELETE FROM `creature` WHERE `id1`=12795;
+INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (12795, 1, 1673.9, -4216, 56.3826, 2.93578, 180);
+
+-- Raider Bork <Mount Quartermaster>
+DELETE FROM `creature` WHERE `id1`=12796;
+INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (12796, 1, 1674.43, -4212.55, 56.3829, 3.00254, 1290);
+
+-- Sergeant Ba'sha <Accessories Quartermaster>
+DELETE FROM `creature` WHERE `id1`=12799;
+INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (12799, 1, 1632.21, -4262.19, 49.027, 3.63029, 430);
+
+-- Sergeant Thunderhorn <Weapons Quartermaster>
+DELETE FROM `creature` WHERE `id1`=14581;
+INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (14581, 1, 1644.52, -4195.26, 56.3826, 5.43078, 180);
+
+-- High Overlord Saurfang
+DELETE FROM `creature` WHERE `id1`=14720;
+INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (14720, 1, 1565.79, -4395.27, 6.9866, 3.35103, 600);
+
+-- Kartra Bloodsnarl <Alterac Valley Battlemaster>
+DELETE FROM `creature` WHERE `id1`=14942;
+INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (14942, 1, 1980.9, -4787.78, 55.8796, 5.13127, 600);
+
+-- Deze Snowbane <Arathis Basin Battlemaster>
+DELETE FROM `creature` WHERE `id1`=15006;
+INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (15006, 1, 2002.26, -4796.74, 56.8471, 3.00197, 600);
+
+-- Summon Felsteed (Warlock)
+DELETE FROM `creature_queststarter` WHERE `id`=3326 AND `quest`=3631;
+INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (3326, 3631);
+
+-- Knowledge of the Orb of Orahil (Warlock)
+DELETE FROM `creature_queststarter` WHERE `id`=3326 AND `quest`=4967;
+INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (3326, 4967);
+
+-- An Imp's Request (Warlock)
+DELETE FROM `creature_queststarter` WHERE `id` IN (3324, 3325, 3326, 4564, 5495, 5496) AND `quest`=8419;
+INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (3326, 8419);
+
+-- Vol'jin <King of Darkspear Trolls>
+UPDATE `creature_template` SET `subname`='King of Darkspear Trolls', `minlevel`=60, `maxlevel`=60 WHERE `entry`=10540;
+
+-- Nazgrel <Advisor to Thrall>
+UPDATE `creature_template` SET `scale`=0.7, `npcflag`=2, `faction`=29, `gossip_menu_id`=0 WHERE `entry`=3230;
+
+-- Orgrimmar Grunt
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=3296;
+
+-- Doras <Wind Rider Master>
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=3310;
+
+-- Trak'gen <General Goods Merchant>
+UPDATE `creature_template` SET `subname`='General Goods Merchant' WHERE `entry`=3313;
+
+-- Kaja <Guns and Ammo Merchant>
+UPDATE `creature_template` SET `subname`='Guns and Ammo Merchant' WHERE `entry`=3322;
+
+-- Horthus <Reagents Vendor>
+UPDATE `creature_template` SET `subname`='Reagents Vendor' WHERE `entry`=3323;
+
+-- Rekkul <Poison Vendor>
+UPDATE `creature_template` SET `subname`='Poison Vendor' WHERE `entry`=3334;
+
+-- Hagrus <Reagents Vendor>
+UPDATE `creature_template` SET `subname`='Reagents Vendor' WHERE `entry`=3335;
+
+-- Asoran <General Goods Vendor>
+UPDATE `creature_template` SET `subname`='General Goods Vendor' WHERE `entry`=3350;
+
+-- Magenius <Reagents Vendor>
+UPDATE `creature_template` SET `subname`='Reagents Vendor' WHERE `entry`=3351;
+
+-- Sumi <Blacksmithing Supplier>
+UPDATE `creature_template` SET `subname`='Blacksmithing Supplier' WHERE `entry`=3356;
+
+-- Gorina <Mining Supplier>
+UPDATE `creature_template` SET `subname`='Mining Supplier' WHERE `entry`=3358;
+
+-- Felika <General Trade Goods Merchant>
+UPDATE `creature_template` SET `subname`='General Trade Goods Merchant' WHERE `entry`=3367;
+
+-- Xen'to <Cooking Supplier>
+UPDATE `creature_template` SET `subname`='Cooking Supplier' WHERE `entry`=3400;
+
+-- Thrall <Warchief>
+UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=4949;
+
+-- Shimra <General Trade Goods Merchant>
+UPDATE `creature_template` SET `subname`='General Trade Goods Merchant' WHERE `entry`=5817;
+
+-- Snurk Bucksquick <Zeppelin Master>
+UPDATE `creature_template` SET `subname`='Zeppelin Master' WHERE `entry`=12136;
+
+-- Legionnaire Teena
+UPDATE `creature_template` SET `subname`=NULL, `npcflag`=0, `faction`=85 WHERE `entry`=12788;
+
+-- Lady Palanseer <Armor Quartermaster>
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=12792;
+
+-- Brave Stonehide <Officer Accessories Quartermaster>
+UPDATE `creature_template` SET `subname`='Officer Accessories Quartermaster' WHERE `entry`=12793;
+
+-- First Sergeant Hola'mahi <Reagent Vendor>
+UPDATE `creature_template` SET `subname`='Reagent Vendor' WHERE `entry`=12795;
+
+-- Stone Guard Zarg <Food and Drink>
+UPDATE `creature_template` SET `subname`='Food and Drink' WHERE `entry`=12794;
+
+-- Raider Bork <Mount Quartermaster>
+UPDATE `creature_template` SET `subname`='Mount Quartermaster' WHERE `entry`=12796;
+
+-- Kor'kron Elite
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60, `rank`=0 WHERE `entry`=14304;
+
+-- Scout Stronghand
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14375;
+
+-- Scout Manslayer
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14376;
+
+-- Scout Tharr
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14377;
+
+-- Sergeant Thunderhorn <Weapons Quartermaster>
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=14581;
+
+-- High Overlord Saurfang
+UPDATE `creature_template` SET `minlevel`=62, `maxlevel`=62 WHERE `entry`=14720;
+
+-- Horde Warbringer
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60, `rank`=0 WHERE `entry`=15350;
+
+-- Raider Bork <Mount Quartermaster>
+UPDATE `creature_template_addon` SET `mount`=0 WHERE `entry`=12796;
+
 -- Olvia <Meat Vendor>
 DELETE FROM `npc_vendor` WHERE `entry`=3312 AND `item` IN (27854, 33454, 35953);
 
@@ -427,197 +442,69 @@ DELETE FROM `npc_vendor` WHERE `entry`=6929 AND `item` IN (27854, 28399, 33444, 
 DELETE FROM `npc_vendor` WHERE `entry`=12788;
 
 -- Lady Palanseer <Armor Quartermaster>
-DELETE FROM `npc_vendor` WHERE `entry`=12792 AND `item` IN (16533, 16534, 16535, 16536, 16539, 16540, 16541, 16542, 16543, 16544, 16545, 16548, 16549, 16550, 16551, 16552, 16554, 16555, 16558, 16560, 16561, 16562, 16563, 16564, 16565, 16566, 16567, 16568, 16569, 16571, 16573, 16574, 16577, 16578, 16579, 16580, 17586, 17588, 17590, 17591, 17592, 17593, 17618, 17620, 17622, 17623, 17624, 17625, 22843, 22852, 22855, 22856, 22857, 22858, 22859, 22860, 22862, 22863, 22864, 22865, 22867, 22868, 22869, 22870, 22872, 22873, 22874, 22875, 22876, 22877, 22878, 22879, 22880, 22881, 22882, 22883, 22884, 22885, 22886, 22887, 23243, 23244, 23251, 23252, 23253, 23254, 23255, 23256, 23257, 23258, 23259, 23260, 23261, 23262, 23263, 23264);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16533, 464);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16534, 542);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16535, 463);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16536, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16539, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16540, 541);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16541, 463);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16542, 464);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16543, 542);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16544, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16545, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16548, 541);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16549, 463);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16550, 464);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16551, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16552, 542);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16554, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16555, 541);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16558, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16560, 541);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16561, 464);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16562, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16563, 463);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16564, 542);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16565, 463);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16566, 464);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16567, 542);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16568, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16569, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16571, 541);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16573, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16574, 541);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16577, 463);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16578, 464);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16579, 542);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 16580, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 17586, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 17588, 541);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 17590, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 17591, 464);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 17592, 463);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 17593, 542);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 17618, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 17620, 541);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 17622, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 17623, 464);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 17624, 463);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 17625, 542);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22843, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22852, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22855, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22856, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22857, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22858, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22859, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22860, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22862, 428);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22863, 428);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22864, 428);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22865, 428);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22867, 428);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22868, 428);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22869, 428);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22870, 428);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22872, 652);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22873, 653);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22874, 652);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22875, 653);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22876, 652);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22877, 652);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22878, 653);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22879, 652);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22880, 653);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22881, 653);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22882, 653);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22883, 653);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22884, 652);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22885, 652);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22886, 652);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 22887, 653);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 23243, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 23244, 444);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 23251, 444);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 23252, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 23253, 444);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 23254, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 23255, 444);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 23256, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 23257, 444);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 23258, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 23259, 444);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 23260, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 23261, 444);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 23262, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 23263, 444);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12792, 23264, 427);
+DELETE FROM `npc_vendor` WHERE `entry`=12792 AND `item` IN 
+    (16533, 16534, 16535, 16536, 16539, 16540, 16541, 16542, 16543, 16544, 16545, 16548, 16549, 16550, 16551, 16552, 16554, 16555, 16558, 
+    16560, 16561, 16562, 16563, 16564, 16565, 16566, 16567, 16568, 16569, 16571, 16573, 16574, 16577, 16578, 16579, 16580, 17586, 17588, 
+    17590, 17591, 17592, 17593, 17618, 17620, 17622, 17623, 17624, 17625, 22843, 22852, 22855, 22856, 22857, 22858, 22859, 
+    22860, 22862, 22863, 22864, 22865, 22867, 22868, 22869, 22870, 22872, 22873, 22874, 22875, 22876, 22877, 22878, 22879, 
+    22880, 22881, 22882, 22883, 22884, 22885, 22886, 22887, 23243, 23244, 23251, 23252, 23253, 23254, 23255, 23256, 23257, 23258, 23259, 23260, 23261, 23262, 23263, 23264);
+
+INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES
+    (12792, 16533, 464), (12792, 16534, 542), (12792, 16535, 463), (12792, 16536, 465), (12792, 16539, 465), (12792, 16540, 541), (12792, 16541, 463), (12792, 16542, 464), (12792, 16543, 542),
+    (12792, 16544, 465), (12792, 16545, 465), (12792, 16548, 541), (12792, 16549, 463), (12792, 16550, 464), (12792, 16551, 465), (12792, 16552, 542), (12792, 16554, 465), (12792, 16555, 541),
+    (12792, 16558, 465), (12792, 16560, 541), (12792, 16561, 464), (12792, 16562, 465), (12792, 16563, 463), (12792, 16564, 542), (12792, 16565, 463), (12792, 16566, 464), (12792, 16567, 542),
+    (12792, 16568, 465), (12792, 16569, 465), (12792, 16571, 541), (12792, 16573, 465), (12792, 16574, 541), (12792, 16577, 463), (12792, 16578, 464), (12792, 16579, 542), (12792, 16580, 465),    
+    (12792, 17586, 465), (12792, 17588, 541), (12792, 17590, 465), (12792, 17591, 464), (12792, 17592, 463), (12792, 17593, 542), (12792, 17618, 465), (12792, 17620, 541), (12792, 17622, 465),
+    (12792, 17623, 464), (12792, 17624, 463), (12792, 17625, 542), (12792, 22843, 427), (12792, 22852, 427), (12792, 22855, 427), (12792, 22856, 427), (12792, 22857, 427), (12792, 22858, 427),
+    (12792, 22859, 427), (12792, 22860, 427), (12792, 22862, 428), (12792, 22863, 428), (12792, 22864, 428), (12792, 22865, 428), (12792, 22867, 428), (12792, 22868, 428), (12792, 22869, 428),
+    (12792, 22870, 428), (12792, 22872, 652), (12792, 22873, 653), (12792, 22874, 652), (12792, 22875, 653), (12792, 22876, 652), (12792, 22877, 652), (12792, 22878, 653), (12792, 22879, 652),
+    (12792, 22880, 653), (12792, 22881, 653), (12792, 22882, 653), (12792, 22883, 653), (12792, 22884, 652), (12792, 22885, 652), (12792, 22886, 652), (12792, 22887, 653), (12792, 23243, 427),
+    (12792, 23244, 444), (12792, 23251, 444), (12792, 23252, 427), (12792, 23253, 444), (12792, 23254, 427), (12792, 23255, 444), (12792, 23256, 427), (12792, 23257, 444), (12792, 23258, 427),
+    (12792, 23259, 444), (12792, 23260, 427), (12792, 23261, 444), (12792, 23262, 427), (12792, 23263, 444), (12792, 23264, 427);
 
 -- Brave Stonehide <Officer Accessories Quartermaster>
 DELETE FROM `npc_vendor` WHERE `entry`=12793 AND `item` IN (15197, 15200, 16335, 16341, 16486, 16497, 16532, 18427, 18428, 18429, 18430, 18432, 18434, 18435, 18436, 18437, 18461, 18834, 18845, 18846, 18849, 18850, 18851, 18852, 18853, 24551, 28118, 28119, 28120, 28123, 28239, 28240, 28241, 28242, 28243, 28246, 28247, 28362, 28363, 28377, 28378, 29592, 30343, 30344, 30345, 30346, 31838, 31839, 31840, 31841, 31852, 31853, 31854, 31855, 32453, 32455, 37865, 38588, 44957);
 
 -- First Sergeant Hola'mahi <Reagent Vendor>
-DELETE FROM `npc_vendor` WHERE `entry`=12795 AND `item` IN (16533, 16534, 16535, 16536, 16539, 16540, 16541, 16542, 16543, 16544, 16545, 16548, 16549, 16550, 16551, 16552, 16554, 16555, 16558, 16560, 16561, 16562, 16563, 16564, 16565, 16566, 16567, 16568, 16569, 16571, 16573, 16574, 16577, 16578, 16579, 16580, 17586, 17588, 17590, 17591, 17592, 17593, 17618, 17620, 17622, 17623, 17624, 17625, 22843, 22852, 22855, 22856, 22857, 22858, 22859, 22860, 22862, 22863, 22864, 22865, 22867, 22868, 22869, 22870, 22872, 22873, 22874, 22875, 22876, 22877, 22878, 22879, 22880, 22881, 22882, 22883, 22884, 22885, 22886, 22887, 23243, 23244, 23251, 23252, 23253, 23254, 23255, 23256, 23257, 23258, 23259, 23260, 23261, 23262, 23263, 23264, 29600, 29601, 29602, 29603, 29604, 29605, 29612, 29613, 29614, 29615, 29616, 29617);
+DELETE FROM `npc_vendor` WHERE `entry`=12795 AND `item` IN 
+    (16533, 16534, 16535, 16536, 16539, 16540, 16541, 16542, 16543, 16544, 16545, 16548, 16549, 16550, 16551, 16552, 16554, 16555, 16558, 
+    16560, 16561, 16562, 16563, 16564, 16565, 16566, 16567, 16568, 16569, 16571, 16573, 16574, 16577, 16578, 16579, 16580, 17586, 17588, 
+    17590, 17591, 17592, 17593, 17618, 17620, 17622, 17623, 17624, 17625, 22843, 22852, 22855, 22856, 22857, 22858, 22859, 
+    22860, 22862, 22863, 22864, 22865, 22867, 22868, 22869, 22870, 22872, 22873, 22874, 22875, 22876, 22877, 22878, 22879, 
+    22880, 22881, 22882, 22883, 22884, 22885, 22886, 22887, 23243, 23244, 23251, 23252, 23253, 23254, 23255, 23256, 23257, 23258, 23259, 
+    23260, 23261, 23262, 23263, 23264, 29600, 29601, 29602, 29603, 29604, 29605, 29612, 29613, 29614, 29615, 29616, 29617);
+
 DELETE FROM `npc_vendor` WHERE `entry`=12795 AND `item` IN (5565, 16583, 17020, 17021, 17026, 17028, 17029, 17030, 17031, 17032, 17033, 17034, 17035, 17036, 17037, 17038);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12795, 5565);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12795, 16583);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12795, 17020);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12795, 17021);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12795, 17026);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12795, 17028);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12795, 17029);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12795, 17030);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12795, 17031);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12795, 17032);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12795, 17033);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12795, 17034);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12795, 17035);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12795, 17036);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12795, 17037);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12795, 17038);
+INSERT INTO `npc_vendor` (`entry`, `item`) VALUES
+    (12795, 5565), (12795, 16583), (12795, 17020), (12795, 17021), (12795, 17026), (12795, 17028), (12795, 17029), (12795, 17030),
+    (12795, 17031), (12795, 17032), (12795, 17033), (12795, 17034), (12795, 17035), (12795, 17036), (12795, 17037), (12795, 17038);
 
 -- Stone Guard Zarg <Food and Drink>
-DELETE FROM `npc_vendor` WHERE `entry`=12794 AND `item` IN (16345, 18826, 18828, 18831, 18835, 18837, 18840, 18844, 18848, 18860, 18866, 18868, 18871, 18874, 18877, 23464, 23465, 23466, 23467, 23468, 23469);
-DELETE FROM `npc_vendor` WHERE `entry`=12794 AND `item` IN (117, 159, 1179, 1205, 1645, 1708, 2287, 2593, 2594, 2595, 2596, 2723, 3770, 3771, 4536, 4537, 4538, 4539, 4540, 4541, 4542, 4544, 4599, 4601, 4602, 4604, 4605, 4606, 4607, 4608, 8766, 8948, 8950, 8952, 8953);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 117);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 159);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 1179);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 1205);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 1645);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 1708);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 2287);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 2593);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 2594);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 2595);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 2596);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 2723);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 3770);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 3771);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 4536);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 4537);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 4538);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 4539);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 4540);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 4541);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 4542);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 4544);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 4599);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 4601);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 4602);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 4604);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 4605);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 4606);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 4607);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 4608);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 8766);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 8948);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 8950);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 8952);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12794, 8953);
+DELETE FROM `npc_vendor` WHERE `entry`=12794 AND `item` IN 
+    (16345, 18826, 18828, 18831, 18835, 18837, 18840, 18844, 18848, 18860, 18866, 18868, 18871, 18874, 18877, 23464, 23465, 23466, 23467, 23468, 23469);
+DELETE FROM `npc_vendor` WHERE `entry`=12794 AND `item` IN
+    (117, 159, 1179, 1205, 1645, 1708, 2287, 2593, 2594, 2595, 2596, 2723, 3770, 3771, 4536, 4537, 4538, 4539, 4540, 4541, 4542, 4544, 4599, 4601, 4602, 4604, 4605, 4606, 4607, 4608, 8766, 8948, 8950, 8952, 8953);
+
+INSERT INTO `npc_vendor` (`entry`, `item`) VALUES
+    (12794, 117), (12794, 159), (12794, 1179), (12794, 1205), (12794, 1645), (12794, 1708), (12794, 2287), (12794, 2593), (12794, 2594), (12794, 2595), (12794, 2596), (12794, 2723),
+    (12794, 3770), (12794, 3771), (12794, 4536), (12794, 4537), (12794, 4538), (12794, 4539), (12794, 4540), (12794, 4541), (12794, 4542), (12794, 4544), (12794, 4599), (12794, 4601);
+    (12794, 4602), (12794, 4604), (12794, 4605), (12794, 4606), (12794, 4607), (12794, 4608), (12794, 8766), (12794, 8948), (12794, 8950), (12794, 8952), (12794, 8953);
 
 -- Raider Bork <Mount Quartermaster>
 DELETE FROM `npc_vendor` WHERE `entry`=12796 AND `item` IN (29466, 29469, 29470, 29472, 34129);
 DELETE FROM `npc_vendor` WHERE `entry`=12796 AND `item` IN (18245, 18246, 18247, 18248);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12796, 18245, 423);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12796, 18246, 423);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12796, 18247, 423);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12796, 18248, 423);
+INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES 
+    (12796, 18245, 423), 
+    (12796, 18246, 423), 
+    (12796, 18247, 423), 
+    (12796, 18248, 423);
 
 -- Sergeant Thunderhorn <Weapons Quartermaster>
 DELETE FROM `npc_vendor` WHERE `entry`=14581 AND `item` IN (16345, 18826, 18828, 18831, 18835, 18837, 18840, 18844, 18848, 18860, 18866, 18868, 18871, 18874, 18877, 23464, 23465, 23466, 23467, 23468, 23469);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (14581, 16345, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (14581, 18826, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (14581, 18828, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (14581, 18831, 2257);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (14581, 18835, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (14581, 18837, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (14581, 18840, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (14581, 18844, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (14581, 18848, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (14581, 18860, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (14581, 18866, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (14581, 18868, 2257);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (14581, 18871, 2257);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (14581, 18874, 2257);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (14581, 18877, 2257);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (14581, 23464, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (14581, 23465, 2257);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (14581, 23466, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (14581, 23467, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (14581, 23468, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (14581, 23469, 2291);
+INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES
+    (14581, 16345, 2291), (14581, 18826, 2291), (14581, 18828, 2291), (14581, 18831, 2257), (14581, 18835, 2291), (14581, 18837, 2291), (14581, 18840, 2291), 
+    (14581, 18844, 2291), (14581, 18848, 2291), (14581, 18860, 2291), (14581, 18866, 2291), (14581, 18868, 2257), (14581, 18871, 2257), (14581, 18874, 2257), 
+    (14581, 18877, 2257), (14581, 23464, 2291), (14581, 23465, 2257), (14581, 23466, 2291), (14581, 23467, 2291), (14581, 23468, 2291), (14581, 23469, 2291);
 
 -- Nogg Quest Flags fix
 UPDATE `creature_template` SET `npcflag` = `npcflag` | 2 WHERE `entry` = 3412;

--- a/sql/world/base/zone_orgrimmar.sql
+++ b/sql/world/base/zone_orgrimmar.sql
@@ -49,8 +49,7 @@ UPDATE `creature_template` SET `subname`='Expert Tailor' WHERE `entry`=3363;
 
 -- Snarl <Expert Blacksmith>
 DELETE FROM `npc_trainer` WHERE `ID`=1383;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (1383, -310000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (1383, -310001);
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (1383, -310000), (1383, -310001);
 
 -- Snang <Journeyman Tailor>
 DELETE FROM `npc_trainer` WHERE `ID`=2855;
@@ -66,19 +65,15 @@ INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3332, -360000);
 
 -- Godan <Expert Enchanter>
 DELETE FROM `npc_trainer` WHERE `ID`=3345;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3345, -330000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3345, -330001);
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3345, -330000), (3345, -330001);
 
 -- Yelmak <Expert Alchemist>
 DELETE FROM `npc_trainer` WHERE `ID`=3347;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3347, -300000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3347, -300001);
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3347, -300000), (3347, -300001);
 
 -- Saru Steelfury <Artisan Blacksmith>
 DELETE FROM `npc_trainer` WHERE `ID`=3355;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3355, -310000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3355, -310001);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3355, -310002);
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3355, -310000), (3355, -310001), (3355, -310002);
 
 -- Makaru <Mining Trainer>
 DELETE FROM `npc_trainer` WHERE `ID`=3357;
@@ -86,13 +81,11 @@ INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3357, -390000);
 
 -- Magar <Expert Tailor>
 DELETE FROM `npc_trainer` WHERE `ID`=3363;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3363, -410000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3363, -410001);
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3363, -410000), (3363, -410001);
 
 -- Karolek <Expert Leatherworker>
 DELETE FROM `npc_trainer` WHERE `ID`=3365;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3365, -380000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3365, -380001);
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3365, -380000), (3365, -380001);
 
 -- Arnok <First Aid Trainer>
 DELETE FROM `npc_trainer` WHERE `ID`=3373;
@@ -104,8 +97,7 @@ INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3399, -320000);
 
 -- Nogg <Expert Engineer>
 DELETE FROM `npc_trainer` WHERE `ID`=3412;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3412, -340000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3412, -340001);
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3412, -340000), (3412, -340001);
 
 -- Kildar <Riding Trainer>
 DELETE FROM `npc_trainer` WHERE `ID`=4752;
@@ -125,9 +117,7 @@ INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (10266, -310000);
 
 -- Roxxik <Artisan Engineer>
 DELETE FROM `npc_trainer` WHERE `ID`=11017;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11017, -340000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11017, -340001);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11017, -340002);
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11017, -340000), (11017, -340001), (11017, -340002);
 
 -- Whuut <Journeyman Alchemist>
 DELETE FROM `npc_trainer` WHERE `ID`=11046;
@@ -412,11 +402,7 @@ DELETE FROM `npc_vendor` WHERE `entry`=3366 AND `item`=38426;
 -- Felika <General Trade Goods Merchant>
 DELETE FROM `npc_vendor` WHERE `entry`=3367 AND `item` IN (14341, 18256, 20856);
 DELETE FROM `npc_vendor` WHERE `entry`=3367 AND `item` IN (2324, 2605, 6260, 6529);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES
-    (3367, 2324), 
-    (3367, 2605), 
-    (3367, 6260), 
-    (3367, 6529);
+INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (3367, 2324), (3367, 2605), (3367, 6260), (3367, 6529);
 
 -- Borstan <Meat Vendor>
 DELETE FROM `npc_vendor` WHERE `entry`=3368 AND `item` IN (27854, 33454, 35953);
@@ -494,11 +480,7 @@ INSERT INTO `npc_vendor` (`entry`, `item`) VALUES
 -- Raider Bork <Mount Quartermaster>
 DELETE FROM `npc_vendor` WHERE `entry`=12796 AND `item` IN (29466, 29469, 29470, 29472, 34129);
 DELETE FROM `npc_vendor` WHERE `entry`=12796 AND `item` IN (18245, 18246, 18247, 18248);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES 
-    (12796, 18245, 423), 
-    (12796, 18246, 423), 
-    (12796, 18247, 423), 
-    (12796, 18248, 423);
+INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12796, 18245, 423), (12796, 18246, 423), (12796, 18247, 423), (12796, 18248, 423);
 
 -- Sergeant Thunderhorn <Weapons Quartermaster>
 DELETE FROM `npc_vendor` WHERE `entry`=14581 AND `item` IN (16345, 18826, 18828, 18831, 18835, 18837, 18840, 18844, 18848, 18860, 18866, 18868, 18871, 18874, 18877, 23464, 23465, 23466, 23467, 23468, 23469);

--- a/sql/world/base/zone_stormwind.sql
+++ b/sql/world/base/zone_stormwind.sql
@@ -1,30 +1,126 @@
+-- Dane Lindgren <Apprentice Blacksmith>
+UPDATE `creature_template` SET `subname`='Journeyman Blacksmith', `npcflag`=81, `trainer_type`=2 WHERE `entry`=957;
+
+-- Betty Quin <Apprentice Enchanter>
+UPDATE `creature_template` SET `subname`='Journeyman Enchanter', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11068;
+
+-- Lucan Cordell <Enchanting Trainer>
+UPDATE `creature_template` SET `subname`='Expert Enchanter' WHERE `entry`=1317;
+
+-- Sprite Jumpsprocket <Apprentice Engineer>
+UPDATE `creature_template` SET `subname`='Journeyman Engineer', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11026;
+
+-- Randal Worth <Apprentice Leatherworker>
+UPDATE `creature_template` SET `subname`='Journeyman Leatherworker', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11096;
+
+-- Lawrence Schneider <Apprentice Tailor>
+UPDATE `creature_template` SET `subname`='Journeyman Tailor', `npcflag`=81, `trainer_type`=2 WHERE `entry`=1300;
+
+-- Sellandus <Expert Tailor>
+UPDATE `creature_template` SET `type_flags`=134217728 WHERE `entry`=5567;
+    
+-- Georgio Bolero <Artisan Tailor>
+UPDATE `creature_template` SET `subname`='Artisan Tailor' WHERE `entry`=1346;
+
+
+-- Tel'Athir <Journeyman Alchemist>
+DELETE FROM `npc_trainer` WHERE `ID`=5500;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5500, -300000);
+
+-- Lilyssia Nightbreeze <Expert Alchemist>
+DELETE FROM `npc_trainer` WHERE `ID`=5499;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5499, -300000), (5499, -300001);
+
+-- Dane Lindgren <Journeyman Blacksmith>
+DELETE FROM `npc_trainer` WHERE `ID`=957;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (957, -310000);
+
+-- Therum Deepforge <Expert Blacksmith>
+DELETE FROM `npc_trainer` WHERE `ID`=5511;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5511, -310000), (5511, -310001);
+
+-- Betty Quin <Journeyman Enchanter>
+DELETE FROM `npc_trainer` WHERE `ID`=11068;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11068, -330000);
+
+-- Lucan Cordell <Expert Enchanter>
+DELETE FROM `npc_trainer` WHERE `ID`=1317;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (1317, -330000), (1317, -330001);
+
+-- Sprite Jumpsprocket <Journeyman Engineer>
+DELETE FROM `npc_trainer` WHERE `ID`=11026;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11026, -340000);
+
+-- Lilliam Sparkspindle <Expert Engineer>
+DELETE FROM `npc_trainer` WHERE `ID`=5518;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5518, -340000), (5518, -340001);
+
+-- Randal Worth <Journeyman Leatherworker>
+DELETE FROM `npc_trainer` WHERE `ID`=11096;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11096, -380000);
+
+-- Simon Tanner <Expert Leatherworker>
+DELETE FROM `npc_trainer` WHERE `ID`=5564;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5564, -380000), (5564, -380001);
+
+-- Lawrence Schneider <Journeyman Tailor>
+DELETE FROM `npc_trainer` WHERE `ID`=1300;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (1300, -410000);
+
+-- Sellandus <Expert Tailor>
+DELETE FROM `npc_trainer` WHERE `ID`=5567;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5567, -410000), (5567, -410001);
+
+-- Georgio Bolero <Artisan Tailor>
+DELETE FROM `npc_trainer` WHERE `ID`=1346;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (1346, -410000), (1346, -410001), (1346, -410002);
+
+
+-- Lucan Cordell <Expert Enchanter>
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=4161;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES 
+(4161, 0, 3, 'Train me.', 3266, 5, 16);
+
+-- Sellandus <Expert Tailor>
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=4344;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES 
+(4344, 0, 3, 'Train me.', 3266, 5, 16);
+
+
 -- Therum Deepforge <Expert Blacksmith>
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=581 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES (15, 581, 0, 7, 164, 50, 'Show menu if blacksmithing is 50 or higher');
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES 
+(15, 581, 0, 7, 164, 50, 'Show menu if blacksmithing is 50 or higher');
 
 -- Lilliam Sparkspindle <Expert Engineer>
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4146 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES (15, 4146, 0, 7, 202, 50, 'Show menu if engineering is 50 or higher');
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES 
+(15, 4146, 0, 7, 202, 50, 'Show menu if engineering is 50 or higher');
 
 -- Lucan Cordell <Expert Enchanter>
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4161 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES (15, 4161, 0, 7, 333, 50, 'Show menu if enchanting is 50 or higher');
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES 
+(15, 4161, 0, 7, 333, 50, 'Show menu if enchanting is 50 or higher');
 
 -- Lilyssia Nightbreeze <Expert Alchemist>
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4201 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES (15, 4201, 0, 7, 171, 50, 'Show menu if alchemy is 50 or higher');
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 4201, 0, 7, 171, 50, 'Show menu if alchemy is 50 or higher');
 
 -- Simon Tanner <Expert Leatherworker>
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4203 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES (15, 4203, 0, 7, 165, 50, 'Show menu if leatherworking is 50 or higher');
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES 
+(15, 4203, 0, 7, 165, 50, 'Show menu if leatherworking is 50 or higher');
 
 -- Sellandus <Expert Tailor>
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4344 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES (15, 4344, 0, 7, 197, 50, 'Show menu if tailoring is 50 or higher');
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES 
+(15, 4344, 0, 7, 197, 50, 'Show menu if tailoring is 50 or higher');
 
 -- Georgio Bolero <Artisan Tailor>
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4353 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES (15, 4353, 0, 7, 197, 125, 'Show menu if tailoring is 125 or higher');
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 4353, 0, 7, 197, 125, 'Show menu if tailoring is 125 or higher');
 
 
 -- Thelman Slatefist <Alterac Valley Battlemaster>
@@ -111,9 +207,6 @@ UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=352;
 -- General Marcus Jonathan <High Commander of Stormwind Defense>
 UPDATE `creature_template` SET `minlevel`=62, `maxlevel`=62 WHERE `entry`=466;
 
--- Dane Lindgren <Apprentice Blacksmith>
-UPDATE `creature_template` SET `subname`='Journeyman Blacksmith', `npcflag`=81, `trainer_type`=2 WHERE `entry`=957;
-
 -- Keldric Boucher <Alchemy Supplies & Reagents>
 UPDATE `creature_template` SET `subname`='Arcane Goods Vendor' WHERE `entry`=1257;
 
@@ -123,20 +216,11 @@ UPDATE `creature_template` SET `subname`='Reagent Vendor' WHERE `entry`=1275;
 -- Edna Mullby <Trade Supplies>
 UPDATE `creature_template` SET `subname`='Trade Supplier' WHERE `entry`=1286;
 
--- Lawrence Schneider <Apprentice Tailor>
-UPDATE `creature_template` SET `subname`='Journeyman Tailor', `npcflag`=81, `trainer_type`=2 WHERE `entry`=1300;
-
 -- Owen Vaughn <Reagents>
 UPDATE `creature_template` SET `subname`='Reagent Vendor' WHERE `entry`=1308;
 
--- Lucan Cordell <Enchanting Trainer>
-UPDATE `creature_template` SET `subname`='Expert Enchanter' WHERE `entry`=1317;
-
 -- Sloan McCoy <Poison Supplier>
 UPDATE `creature_template` SET `subname`='Poison Supplier' WHERE `entry`=1326;
-
--- Georgio Bolero <Tailoring Trainer>
-UPDATE `creature_template` SET `subname`='Artisan Tailor' WHERE `entry`=1346;
 
 -- Brother Cassius <Reagents>
 UPDATE `creature_template` SET `subname`='Reagent Vendor' WHERE `entry`=1351;
@@ -149,15 +233,6 @@ UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=1976;
 
 -- Borgus Steelhand <Weapon Crafter>
 UPDATE `creature_template` SET `subname`='Weapon Crafter' WHERE `entry`=7232;
-
--- Sprite Jumpsprocket <Apprentice Engineer>
-UPDATE `creature_template` SET `subname`='Journeyman Engineer', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11026;
-
--- Betty Quin <Apprentice Enchanter>
-UPDATE `creature_template` SET `subname`='Journeyman Enchanter', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11068;
-
--- Randal Worth <Apprentice Leatherworker>
-UPDATE `creature_template` SET `subname`='Journeyman Leatherworker', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11096;
 
 -- Lieutenant Rachel Vaccar <Outland Armor Quartermaster>
 UPDATE `creature_template` SET `subname`=NULL, `minlevel`=55, `maxlevel`=55, `npcflag`=0 WHERE `entry`=12778;
@@ -192,33 +267,6 @@ UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=29611;
 -- Lieutenant Karter <Mount Vendor>
 UPDATE `creature_template_addon` SET `mount`=0 WHERE `entry`=12783;
 
--- Lucan Cordell <Expert Enchanter>
-DELETE FROM `gossip_menu_option` WHERE `MenuID`=4161;
-INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES (4161, 0, 3, 'Train me.', 3266, 5, 16);
-
--- Sellandus <Expert Tailor>
-DELETE FROM `gossip_menu_option` WHERE `MenuID`=4344;
-INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES (4344, 0, 3, 'Train me.', 3266, 5, 16);
-
--- Dane Lindgren <Journeyman Blacksmith>
-DELETE FROM `npc_trainer` WHERE `ID`=957;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (957, -310000);
-
--- Lawrence Schneider <Journeyman Tailor>
-DELETE FROM `npc_trainer` WHERE `ID`=1300;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (1300, -410000);
-
--- Lucan Cordell <Expert Enchanter>
-DELETE FROM `npc_trainer` WHERE `ID`=1317;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (1317, -330000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (1317, -330001);
-
--- Georgio Bolero <Artisan Tailor>
-DELETE FROM `npc_trainer` WHERE `ID`=1346;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (1346, -410000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (1346, -410001);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (1346, -410002);
-
 -- Tomas <Cook>
 DELETE FROM `npc_trainer` WHERE `ID`=1430;
 INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (1430, -320000);
@@ -235,50 +283,9 @@ INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5493, -360000);
 DELETE FROM `npc_trainer` WHERE `ID`=5482;
 INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5482, -320000);
 
--- Lilyssia Nightbreeze <Expert Alchemist>
-DELETE FROM `npc_trainer` WHERE `ID`=5499;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5499, -300000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5499, -300001);
-
--- Tel'Athir <Journeyman Alchemist>
-DELETE FROM `npc_trainer` WHERE `ID`=5500;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5500, -300000);
-
--- Therum Deepforge <Expert Blacksmith>
-DELETE FROM `npc_trainer` WHERE `ID`=5511;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5511, -310000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5511, -310001);
-
 -- Gelman Stonehand <Mining Trainer>
 DELETE FROM `npc_trainer` WHERE `ID`=5513;
 INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5513, -390000);
-
--- Lilliam Sparkspindle <Expert Engineer>
-DELETE FROM `npc_trainer` WHERE `ID`=5518;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5518, -340000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5518, -340001);
-
--- Simon Tanner <Expert Leatherworker>
-DELETE FROM `npc_trainer` WHERE `ID`=5564;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5564, -380000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5564, -380001);
-
--- Sellandus <Expert Tailor>
-DELETE FROM `npc_trainer` WHERE `ID`=5567;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5567, -410000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5567, -410001);
-
--- Sprite Jumpsprocket <Journeyman Engineer>
-DELETE FROM `npc_trainer` WHERE `ID`=11026;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11026, -340000);
-
--- Betty Quin <Journeyman Enchanter>
-DELETE FROM `npc_trainer` WHERE `ID`=11068;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11068, -330000);
-
--- Randal Worth <Journeyman Leatherworker>
-DELETE FROM `npc_trainer` WHERE `ID`=11096;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11096, -380000);
 
 -- Elaine Trias <Mistress of Cheese>
 DELETE FROM `npc_vendor` WHERE `entry`=483 AND `item` IN (27857, 33443, 35952);
@@ -292,11 +299,7 @@ DELETE FROM `npc_vendor` WHERE `entry`=1275 AND `item` IN (22147, 22148, 37201);
 -- Edna Mullby <Trade Supplies>
 DELETE FROM `npc_vendor` WHERE `entry`=1286 AND `item` IN (14341, 18256, 20856);
 DELETE FROM `npc_vendor` WHERE `entry`=1286 AND `item` IN (2324, 2605, 2928, 6260, 6529);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (1286, 2324);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (1286, 2605);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (1286, 2928);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (1286, 6260);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (1286, 6529);
+INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (1286, 2324), (1286, 2605), (1286, 2928), (1286, 6260), (1286, 6529);
 
 -- Frederick Stover <Bow & Arrow Merchant>
 DELETE FROM `npc_vendor` WHERE `entry`=1298 AND `item` IN (11303, 11306, 11307, 28053);
@@ -350,196 +353,70 @@ DELETE FROM `npc_vendor` WHERE `entry`=5565 AND `item`=38426;
 DELETE FROM `npc_vendor` WHERE `entry`=6740 AND `item` IN (4536, 4537, 4538, 4539, 4602, 8953, 27855, 27856, 28399, 33444, 33445, 33449, 35948, 35949, 35950, 35954);
 
 -- Captain Dirgehammer <Armor Quartermaster>
-DELETE FROM `npc_vendor` WHERE `entry`=12777 AND `item` IN (16437, 16440, 16441, 16442, 16443, 16444, 16446, 16448, 16449, 16450, 16451, 16452, 16453, 16454, 16455, 16456, 16457, 16459, 16462, 16463, 16465, 16466, 16467, 16468, 16471, 16472, 16473, 16474, 16475, 16476, 16477, 16478, 16479, 16480, 16483, 16484, 17578, 17579, 17580, 17581, 17583, 17584, 17602, 17603, 17604, 17605, 17607, 17608, 23272, 23273, 23274, 23275, 23276, 23277, 23278, 23279, 23280, 23281, 23282, 23283, 23284, 23285, 23286, 23287, 23288, 23289, 23290, 23291, 23292, 23293, 23294, 23295, 23296, 23297, 23298, 23299, 23300, 23301, 23302, 23303, 23304, 23305, 23306, 23307, 23308, 23309, 23310, 23311, 23312, 23313, 23314, 23315, 23316, 23317, 23318, 23319);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16437, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16440, 541);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16441, 464);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16442, 542);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16443, 463);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16444, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16446, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16448, 541);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16449, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16450, 542);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16451, 464);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16452, 463);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16453, 463);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16454, 541);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16455, 464);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16456, 542);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16457, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16459, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16462, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16463, 541);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16465, 464);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16466, 463);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16467, 542);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16468, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16471, 541);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16472, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16473, 463);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16474, 464);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16475, 542);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16476, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16477, 463);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16478, 464);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16479, 542);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16480, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16483, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 16484, 541);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 17578, 464);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 17579, 542);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 17580, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 17581, 463);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 17583, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 17584, 541);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 17602, 464);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 17603, 542);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 17604, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 17605, 463);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 17607, 465);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 17608, 541);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23272, 652);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23273, 653);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23274, 428);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23275, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23276, 444);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23277, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23278, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23279, 428);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23280, 428);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23281, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23282, 428);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23283, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23284, 428);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23285, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23286, 428);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23287, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23288, 428);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23289, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23290, 428);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23291, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23292, 652);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23293, 653);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23294, 652);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23295, 653);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23296, 653);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23297, 652);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23298, 652);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23299, 653);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23300, 652);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23301, 653);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23302, 653);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23303, 652);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23304, 653);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23305, 652);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23306, 444);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23307, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23308, 444);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23309, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23310, 444);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23311, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23312, 444);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23313, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23314, 444);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23315, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23316, 444);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23317, 427);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23318, 444);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12777, 23319, 427);
+DELETE FROM `npc_vendor` WHERE `entry`=12777 AND `item` IN 
+    (16437, 16440, 16441, 16442, 16443, 16444, 16446, 16448, 16449, 16450, 16451, 16452, 16453, 16454, 16455, 16456, 16457, 16459, 16462, 16463, 16465, 16466, 16467, 16468, 
+    16471, 16472, 16473, 16474, 16475, 16476, 16477, 16478, 16479, 16480, 16483, 16484, 17578, 17579, 17580, 17581, 17583, 17584, 17602, 17603, 17604, 17605, 17607, 17608, 
+    23272, 23273, 23274, 23275, 23276, 23277, 23278, 23279, 23280, 23281, 23282, 23283, 23284, 23285, 23286, 23287, 23288, 23289, 23290, 23291, 23292, 23293, 23294, 23295, 23296, 23297, 23298, 23299, 
+    23300, 23301, 23302, 23303, 23304, 23305, 23306, 23307, 23308, 23309, 23310, 23311, 23312, 23313, 23314, 23315, 23316, 23317, 23318, 23319);
+
+INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES
+    (12777, 16437, 465), (12777, 16440, 541), (12777, 16441, 464), (12777, 16442, 542), (12777, 16443, 463), (12777, 16444, 465), (12777, 16446, 465), (12777, 16448, 541), (12777, 16449, 465),
+    (12777, 16450, 542), (12777, 16451, 464), (12777, 16452, 463), (12777, 16453, 463), (12777, 16454, 541), (12777, 16455, 464), (12777, 16456, 542), (12777, 16457, 465), (12777, 16459, 465),
+    (12777, 16462, 465), (12777, 16463, 541), (12777, 16465, 464), (12777, 16466, 463), (12777, 16467, 542), (12777, 16468, 465), (12777, 16471, 541), (12777, 16472, 465), (12777, 16473, 463),
+    (12777, 16474, 464), (12777, 16475, 542), (12777, 16476, 465), (12777, 16477, 463), (12777, 16478, 464), (12777, 16479, 542), (12777, 16480, 465), (12777, 16483, 465), (12777, 16484, 541),
+    (12777, 17578, 464), (12777, 17579, 542), (12777, 17580, 465), (12777, 17581, 463), (12777, 17583, 465), (12777, 17584, 541), (12777, 17602, 464), (12777, 17603, 542), (12777, 17604, 465),
+    (12777, 17605, 463), (12777, 17607, 465), (12777, 17608, 541), (12777, 23272, 652), (12777, 23273, 653), (12777, 23274, 428), (12777, 23275, 427), (12777, 23276, 444), (12777, 23277, 427),
+    (12777, 23278, 427), (12777, 23279, 428), (12777, 23280, 428), (12777, 23281, 427), (12777, 23282, 428), (12777, 23283, 427), (12777, 23284, 428), (12777, 23285, 427), (12777, 23286, 428),
+    (12777, 23287, 427), (12777, 23288, 428), (12777, 23289, 427), (12777, 23290, 428), (12777, 23291, 427), (12777, 23292, 652), (12777, 23293, 653), (12777, 23294, 652), (12777, 23295, 653),
+    (12777, 23296, 653), (12777, 23297, 652), (12777, 23298, 652), (12777, 23299, 653), (12777, 23300, 652), (12777, 23301, 653), (12777, 23302, 653), (12777, 23303, 652), (12777, 23304, 653),
+    (12777, 23305, 652), (12777, 23306, 444), (12777, 23307, 427), (12777, 23308, 444), (12777, 23309, 427), (12777, 23310, 444), (12777, 23311, 427), (12777, 23312, 444), (12777, 23313, 427),
+    (12777, 23314, 444), (12777, 23315, 427), (12777, 23316, 444), (12777, 23317, 427), (12777, 23318, 444), (12777, 23319, 427);
 
 -- Lieutenant Rachel Vaccar <Outland Armor Quartermaster>
 DELETE FROM `npc_vendor` WHERE `entry`=12778;
 
 -- Master Sergeant Biggins <Accessories Quartermaster>
-DELETE FROM `npc_vendor` WHERE `entry`=12781 AND `item` IN (15196, 16342, 18440, 18441, 18442, 18443, 18444, 18445, 18447, 18448, 18449, 18452, 18453, 18454, 18455, 18456, 18457, 18854, 18856, 18857, 18858, 18859, 18862, 18863, 18864, 25829, 28118, 28119, 28120, 28123, 28234, 28235, 28236, 28237, 28238, 28246, 28247, 28362, 28363, 28379, 28380, 29593, 30348, 30349, 30350, 30351, 31838, 31839, 31840, 31841, 31852, 31853, 31854, 31855, 32453, 32455, 37864, 38589, 44957);
+DELETE FROM `npc_vendor` WHERE `entry`=12781 AND `item` IN 
+    (15196, 16342, 18440, 18441, 18442, 18443, 18444, 18445, 18447, 18448, 18449, 18452, 18453, 18454, 18455, 18456, 18457, 18854, 18856, 18857, 18858, 18859, 
+    18862, 18863, 18864, 25829, 28118, 28119, 28120, 28123, 28234, 28235, 28236, 28237, 28238, 28246, 28247, 28362, 28363, 28379, 28380, 29593, 30348, 30349, 
+    30350, 30351, 31838, 31839, 31840, 31841, 31852, 31853, 31854, 31855, 32453, 32455, 37864, 38589, 44957);
 
 -- Captain O'Neal <Weapons Quartermaster>
 DELETE FROM `npc_vendor` WHERE `entry`=12782 AND `item` IN (12584, 18825, 18827, 18830, 18833, 18836, 18838, 18843, 18847, 18855, 18865, 18867, 18869, 18873, 18876);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12782, 12584, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12782, 18825, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12782, 18827, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12782, 18830, 2257);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12782, 18833, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12782, 18836, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12782, 18838, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12782, 18843, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12782, 18847, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12782, 18855, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12782, 18865, 2291);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12782, 18867, 2257);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12782, 18869, 2257);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12782, 18873, 2257);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12782, 18876, 2257);
+INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES 
+    (12782, 12584, 2291), (12782, 18825, 2291), (12782, 18827, 2291), (12782, 18830, 2257), (12782, 18833, 2291), (12782, 18836, 2291), (12782, 18838, 2291),
+    (12782, 18843, 2291), (12782, 18847, 2291), (12782, 18855, 2291), (12782, 18865, 2291), (12782, 18867, 2257), (12782, 18869, 2257), (12782, 18873, 2257), (12782, 18876, 2257);
 
 -- Lieutenant Karter <War Mount Quartermaster>
 DELETE FROM `npc_vendor` WHERE `entry`=12783 AND `item` IN (29465, 29467, 29468, 29471, 35906);
 DELETE FROM `npc_vendor` WHERE `entry`=12783 AND `item` IN (18241, 18242, 18243, 18244);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12783, 18241, 423);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12783, 18242, 423);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12783, 18243, 423);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12783, 18244, 423);
+INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12783, 18241, 423), (12783, 18242, 423), (12783, 18243, 423), (12783, 18244, 423);
 
 -- Sergeant Major Clate <Legacy Armor Quartermaster>
-DELETE FROM `npc_vendor` WHERE `entry`=12785 AND `item` IN (16437, 16440, 16441, 16442, 16443, 16444, 16446, 16448, 16449, 16450, 16451, 16452, 16453, 16454, 16455, 16456, 16457, 16459, 16462, 16463, 16465, 16466, 16467, 16468, 16471, 16472, 16473, 16474, 16475, 16476, 16477, 16478, 16479, 16480, 16483, 16484, 17578, 17579, 17580, 17581, 17583, 17584, 17602, 17603, 17604, 17605, 17607, 17608, 23272, 23273, 23274, 23275, 23276, 23277, 23278, 23279, 23280, 23281, 23282, 23283, 23284, 23285, 23286, 23287, 23288, 23289, 23290, 23291, 23292, 23293, 23294, 23295, 23296, 23297, 23298, 23299, 23300, 23301, 23302, 23303, 23304, 23305, 23306, 23307, 23308, 23309, 23310, 23311, 23312, 23313, 23314, 23315, 23316, 23317, 23318, 23319, 29594, 29595, 29596, 29597, 29598, 29599, 29606, 29607, 29608, 29609, 29610, 29611);
-DELETE FROM `npc_vendor` WHERE `entry`=12785 AND `item` IN (117, 159, 1179, 1205, 1645, 1708, 2287, 2593, 2594, 2595, 2596, 2723, 3770, 3771, 4536, 4537, 4538, 4539, 4540, 4541, 4542, 4544, 4599, 4601, 4602, 4604, 4605, 4606, 4607, 4608, 8766, 8948, 8950, 8952, 8953);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 117);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 159);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 1179);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 1205);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 1645);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 1708);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 2287);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 2593);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 2594);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 2595);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 2596);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 2723);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 3770);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 3771);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 4536);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 4537);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 4538);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 4539);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 4540);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 4541);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 4542);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 4544);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 4599);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 4601);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 4602);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 4604);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 4605);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 4606);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 4607);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 4608);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 8766);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 8948);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 8950);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 8952);
-INSERT INTO `npc_vendor` (`entry`, `item`) VALUES (12785, 8953);
+DELETE FROM `npc_vendor` WHERE `entry`=12785 AND `item` IN
+    (16437, 16440, 16441, 16442, 16443, 16444, 16446, 16448, 16449, 16450, 16451, 16452, 16453, 16454, 16455, 16456, 16457, 16459, 16462, 16463, 16465, 16466, 16467, 16468, 
+    16471, 16472, 16473, 16474, 16475, 16476, 16477, 16478, 16479, 16480, 16483, 16484, 17578, 17579, 17580, 17581, 17583, 17584, 17602, 17603, 17604, 17605, 17607, 17608, 
+    23272, 23273, 23274, 23275, 23276, 23277, 23278, 23279, 23280, 23281, 23282, 23283, 23284, 23285, 23286, 23287, 23288, 23289, 23290, 23291, 23292, 23293, 23294, 23295, 23296, 23297, 23298, 23299,
+    23300, 23301, 23302, 23303, 23304, 23305, 23306, 23307, 23308, 23309, 23310, 23311, 23312, 23313, 23314, 23315, 23316, 23317, 23318, 23319, 29594, 29595, 29596, 29597, 29598, 29599, 
+    29606, 29607, 29608, 29609, 29610, 29611);
+DELETE FROM `npc_vendor` WHERE `entry`=12785 AND `item` IN 
+    (117, 159, 1179, 1205, 1645, 1708, 2287, 2593, 2594, 2595, 2596, 2723, 3770, 3771, 4536, 4537, 4538, 4539, 4540, 4541, 4542, 4544, 4599, 4601, 4602, 4604, 4605, 4606, 4607, 4608, 8766, 8948, 8950, 8952, 8953);
+
+INSERT INTO `npc_vendor` (`entry`, `item`) VALUES 
+    (12785, 117), (12785, 159), (12785, 1179), (12785, 1205), (12785, 1645), (12785, 1708), (12785, 2287), (12785, 2593), (12785, 2594), (12785, 2595), (12785, 2596), 
+    (12785, 2723), (12785, 3770), (12785, 3771), (12785, 4536), (12785, 4537), (12785, 4538), (12785, 4539), (12785, 4540), (12785, 4541), (12785, 4542), (12785, 4544), (12785, 4599),
+    (12785, 4601), (12785, 4602), (12785, 4604), (12785, 4605), (12785, 4606), (12785, 4607), (12785, 4608), (12785, 8766), (12785, 8948), (12785, 8950), (12785, 8952), (12785, 8953);
 
 -- Officer Areyn <Accessories Quartermaster>
 DELETE FROM `npc_vendor` WHERE `entry`=12805 AND `item` IN (18445, 18447, 18448, 18449, 18454, 18455, 18456, 18457, 18854, 18856, 18858, 18859, 18862, 18863, 18864);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12805, 18445, 492);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12805, 18447, 931);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12805, 18448, 492);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12805, 18449, 931);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12805, 18454, 492);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12805, 18455, 931);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12805, 18456, 492);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12805, 18457, 931);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12805, 18854, 634);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12805, 18856, 634);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12805, 18858, 634);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12805, 18859, 634);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12805, 18862, 634);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12805, 18863, 634);
-INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES (12805, 18864, 634);
+INSERT INTO `npc_vendor` (`entry`, `item`, `ExtendedCost`) VALUES 
+    (12805, 18445, 492), (12805, 18447, 931), (12805, 18448, 492), (12805, 18449, 931), (12805, 18454, 492), (12805, 18455, 931), (12805, 18456, 492), (12805, 18457, 931), 
+    (12805, 18854, 634), (12805, 18856, 634), (12805, 18858, 634), (12805, 18859, 634), (12805, 18862, 634), (12805, 18863, 634), (12805, 18864, 634);
 
 -- Summon Felsteed (Warlock)
 DELETE FROM `quest_offer_reward` WHERE `ID`=4488;
-INSERT INTO `quest_offer_reward` (`ID`, `RewardText`) VALUES (4488, 'So, you\'ve decided to grace my presence again. How kind of you.$b$bMy acolytes wondered if you\'d ever show up. I told them there was no doubt. When power is concerned, you are drawn in like a moth to the flame.');
+INSERT INTO `quest_offer_reward` (`ID`, `RewardText`) VALUES 
+(4488, 'So, you\'ve decided to grace my presence again. How kind of you.$b$bMy acolytes wondered if you\'d ever show up. I told them there was no doubt. When power is concerned, you are drawn in like a moth to the flame.');
 
 -- A Meal Served Cold
 UPDATE `quest_template` SET `Flags`=9, `LogDescription`='Kill a Cold Eye Basilisk, get a Chilled Basilisk Haunch, and return it to Angus Stern in the Blue Recluse.$B$B<You must not release your spirit to succeed in this quest.>' WHERE `ID`=212;

--- a/sql/world/base/zone_thunder_bluff.sql
+++ b/sql/world/base/zone_thunder_bluff.sql
@@ -1,90 +1,20 @@
 -- Karn Stonehoof <Expert Blacksmith>
-DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=1017 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES (15, 1017, 0, 7, 164, 50, 'Show menu if blacksmithing is 50 or higher');
-
--- Bena Winterhoof <Expert Alchemist>
-DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4128 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES (15, 4128, 0, 7, 171, 50, 'Show menu if alchemy is 50 or higher');
-
--- Teg Dawnstrider <Expert Enchanter>
-DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4165 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES (15, 4165, 0, 7, 333, 50, 'Show menu if enchanting is 50 or higher');
-
--- Tarn <Expert Leatherworker>
-DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4207 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES (15, 4207, 0, 7, 165, 50, 'Show menu if leatherworking is 50 or higher');
-
--- Una <Artisan Leatherworker>
-DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4242 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES (15, 4242, 0, 7, 165, 125, 'Show menu if leatherworking is 125 or higher');
-
--- Tepa <Expert Tailor>
-DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4351 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES (15, 4351, 0, 7, 197, 50, 'Show menu if tailoring is 50 or higher');
-
--- Taim Ragetotem
-DELETE FROM `creature` WHERE `id1`=7427;
-INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (7427, 1, -1384.29, -98.6163, 159.018, 2.87979, 300);
-
--- Kergul Bloodaxe <Warsong Gulch Battlemaster>
-DELETE FROM `creature` WHERE `id1`=10360;
-INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (10360, 1, -1381.29, -75.9809, 160.602, 3.19395, 300);
-
--- Martin Lindsey <Arathi Basin Battlemaster>
-DELETE FROM `creature` WHERE `id1`=12198;
-INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (12198, 1, -995.143, 217.173, 104.729, 4.46804, 500);
-
--- Remove WotLK Battlemasters
-DELETE FROM `creature` WHERE `id1`=34978;
-DELETE FROM `creature` WHERE `id1`=34976;
-
--- Karn Stonehoof <Expert Blacksmith>
 UPDATE `creature_template` SET `subname`='Expert Blacksmith' WHERE `entry`=2998;
 
--- Kurm Stonehoof <Mining Supplier>
-UPDATE `creature_template` SET `subname`='Mining Supplier' WHERE `entry`=3002;
-
 -- Tepa <Expert Tailor>
-UPDATE `creature_template` SET `subname`='Expert Tailor' WHERE `entry`=3004;
+UPDATE `creature_template` SET `subname`='Expert Tailor', `type_flags`=134217728 WHERE `entry`=3004;
 
 -- Una <Artisan Leatherworker>
-UPDATE `creature_template` SET `subname`='Artisan Leatherworker' WHERE `entry`=3007;
+UPDATE `creature_template` SET `subname`='Artisan Leatherworker', `type_flags`=134217728 WHERE `entry`=3007;
 
 -- Mak <Journeyman Leatherworker>
 UPDATE `creature_template` SET `subname`='Journeyman Leatherworker', `npcflag`=81, `trainer_type`=2 WHERE `entry`=3008;
 
 -- Bena Winterhoof <Expert Alchemist>
-UPDATE `creature_template` SET `subname`='Expert Alchemist' WHERE `entry`=3009;
+UPDATE `creature_template` SET `subname`='Expert Alchemist', `type_flags`=134217728 WHERE `entry`=3009;
 
 -- Teg Dawnstrider <Expert Enchanter>
-UPDATE `creature_template` SET `subname`='Expert Enchanter' WHERE `entry`=3011;
-
--- Kard Ragetotem <Sword and Dagger Merchant>
-UPDATE `creature_template` SET `subname`='Sword and Dagger Merchant' WHERE `entry`=3021;
-
--- Naal Mistrunner <Cooking Supplier>
-UPDATE `creature_template` SET `subname`='Cooking Supplier' WHERE `entry`=3027;
-
--- Sewa Mistrunner <Fishing Supplier>
-UPDATE `creature_template` SET `subname`='Fishing Supplier' WHERE `entry`=3029;
-
--- Cairne Bloodhoof <High Chieftain>
-UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=3057;
-
--- Honor Guard
-UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60, `rank`=0 WHERE `entry`=3083;
-
--- Bluffwatcher
-UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55, `faction`=105 WHERE `entry`=3084;
-
--- Chepi <Reagent Vendor>
-UPDATE `creature_template` SET `subname`='Reagent Vendor' WHERE `entry`=8361;
-
--- Kuruk <General Goods Vendor>
-UPDATE `creature_template` SET `subname`='General Goods Vendor' WHERE `entry`=8362;
-
--- Shadi Mistrunner <Trade Goods Supplier>
-UPDATE `creature_template` SET `subname`='Trade Goods Supplier' WHERE `entry`=8363;
+UPDATE `creature_template` SET `subname`='Expert Enchanter', `type_flags`=134217728 WHERE `entry`=3011;
 
 -- Thrag Stonehoof <Journeyman Blacksmith>
 UPDATE `creature_template` SET `subname`='Journeyman Blacksmith', `npcflag`=81, `trainer_type`=2 WHERE `entry`=10278;
@@ -99,33 +29,8 @@ UPDATE `creature_template` SET `subname`='Journeyman Tailor', `npcflag`=81, `tra
 UPDATE `creature_template` SET `subname`='Journeyman Enchanter', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11071;
 
 -- Tarn <Expert Leatherworker>
-UPDATE `creature_template` SET `subname`='Expert Leatherworker', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11084;
+UPDATE `creature_template` SET `subname`='Expert Leatherworker', `npcflag`=81, `trainer_type`=2, `type_flags`=134217728 WHERE `entry`=11084;
 
--- Hunter Sagewind
-UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14440;
-
--- Hunter Ragetotem
-UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14441;
-
--- Bena Winterhoof <Expert Alchemist>
-DELETE FROM `gossip_menu_option` WHERE `MenuID`=4128;
-INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES (4128, 0, 3, 'Train me.', 3266, 5, 16);
-
--- Teg Dawnstrider <Expert Enchanter>
-DELETE FROM `gossip_menu_option` WHERE `MenuID`=4165;
-INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES (4165, 0, 3, 'Train me.', 3266, 5, 16);
-
--- Tarn <Expert Leatherworker>
-DELETE FROM `gossip_menu_option` WHERE `MenuID`=4207;
-INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES (4207, 0, 3, 'Train me.', 3266, 5, 16);
-
--- Una <Artisan Leatherworker>
-DELETE FROM `gossip_menu_option` WHERE `MenuID`=4242;
-INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES (4242, 0, 3, 'Train me.', 3266, 5, 16);
-
--- Tepa <Expert Tailor>
-DELETE FROM `gossip_menu_option` WHERE `MenuID`=4351;
-INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES (4351, 0, 3, 'Train me.', 3266, 5, 16);
 
 -- Pand Stonebinder <First Aid Trainer>
 DELETE FROM `npc_trainer` WHERE `ID`=2798;
@@ -201,6 +106,111 @@ INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11071, -330000);
 DELETE FROM `npc_trainer` WHERE `ID`=11084;
 INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11084, -380000);
 INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11084, -380001);
+
+
+-- Bena Winterhoof <Expert Alchemist>
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=4128;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES (4128, 0, 3, 'Train me.', 3266, 5, 16);
+
+-- Teg Dawnstrider <Expert Enchanter>
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=4165;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES (4165, 0, 3, 'Train me.', 3266, 5, 16);
+
+-- Tarn <Expert Leatherworker>
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=4207;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES (4207, 0, 3, 'Train me.', 3266, 5, 16);
+
+-- Una <Artisan Leatherworker>
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=4242;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES (4242, 0, 3, 'Train me.', 3266, 5, 16);
+
+-- Tepa <Expert Tailor>
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=4351;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES (4351, 0, 3, 'Train me.', 3266, 5, 16);
+
+
+-- Karn Stonehoof <Expert Blacksmith>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=1017 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 1017, 0, 7, 164, 50, 'Show menu if blacksmithing is 50 or higher');
+
+-- Bena Winterhoof <Expert Alchemist>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4128 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 4128, 0, 7, 171, 50, 'Show menu if alchemy is 50 or higher');
+
+-- Teg Dawnstrider <Expert Enchanter>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4165 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 4165, 0, 7, 333, 50, 'Show menu if enchanting is 50 or higher');
+
+-- Tarn <Expert Leatherworker>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4207 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 4207, 0, 7, 165, 50, 'Show menu if leatherworking is 50 or higher');
+
+-- Una <Artisan Leatherworker>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4242 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 4242, 0, 7, 165, 125, 'Show menu if leatherworking is 125 or higher');
+
+-- Tepa <Expert Tailor>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4351 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 4351, 0, 7, 197, 50, 'Show menu if tailoring is 50 or higher');
+
+
+-- Taim Ragetotem
+DELETE FROM `creature` WHERE `id1`=7427;
+INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (7427, 1, -1384.29, -98.6163, 159.018, 2.87979, 300);
+
+-- Kergul Bloodaxe <Warsong Gulch Battlemaster>
+DELETE FROM `creature` WHERE `id1`=10360;
+INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (10360, 1, -1381.29, -75.9809, 160.602, 3.19395, 300);
+
+-- Martin Lindsey <Arathi Basin Battlemaster>
+DELETE FROM `creature` WHERE `id1`=12198;
+INSERT INTO `creature` (`id1`, `map`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`) VALUES (12198, 1, -995.143, 217.173, 104.729, 4.46804, 500);
+
+-- Remove WotLK Battlemasters
+DELETE FROM `creature` WHERE `id1`=34978;
+DELETE FROM `creature` WHERE `id1`=34976;
+
+-- Hunter Sagewind
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14440;
+
+-- Hunter Ragetotem
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14441;
+
+-- Kard Ragetotem <Sword and Dagger Merchant>
+UPDATE `creature_template` SET `subname`='Sword and Dagger Merchant' WHERE `entry`=3021;
+
+-- Naal Mistrunner <Cooking Supplier>
+UPDATE `creature_template` SET `subname`='Cooking Supplier' WHERE `entry`=3027;
+
+-- Sewa Mistrunner <Fishing Supplier>
+UPDATE `creature_template` SET `subname`='Fishing Supplier' WHERE `entry`=3029;
+
+-- Cairne Bloodhoof <High Chieftain>
+UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=3057;
+
+-- Honor Guard
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60, `rank`=0 WHERE `entry`=3083;
+
+-- Bluffwatcher
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55, `faction`=105 WHERE `entry`=3084;
+
+-- Chepi <Reagent Vendor>
+UPDATE `creature_template` SET `subname`='Reagent Vendor' WHERE `entry`=8361;
+
+-- Kuruk <General Goods Vendor>
+UPDATE `creature_template` SET `subname`='General Goods Vendor' WHERE `entry`=8362;
+
+-- Shadi Mistrunner <Trade Goods Supplier>
+UPDATE `creature_template` SET `subname`='Trade Goods Supplier' WHERE `entry`=8363;
+
+-- Kurm Stonehoof <Mining Supplier>
+UPDATE `creature_template` SET `subname`='Mining Supplier' WHERE `entry`=3002;
 
 -- Kurm Stonehoof <Mining Supplier>
 DELETE FROM `npc_vendor` WHERE `entry`=3002 AND `item` IN (20815, 20824);

--- a/sql/world/base/zone_thunder_bluff.sql
+++ b/sql/world/base/zone_thunder_bluff.sql
@@ -38,8 +38,7 @@ INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (2798, -350000);
 
 -- Karn Stonehoof <Expert Blacksmith>
 DELETE FROM `npc_trainer` WHERE `ID`=2998;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (2998, -310000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (2998, -310001);
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (2998, -310000), (2998, -310001);
 
 -- Brek Stonehoof <Mining Trainer>
 DELETE FROM `npc_trainer` WHERE `ID`=3001;
@@ -47,14 +46,11 @@ INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3001, -390000);
 
 -- Tepa <Expert Tailor>
 DELETE FROM `npc_trainer` WHERE `ID`=3004;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3004, -410000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3004, -410001);
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3004, -410000), (3004, -410001);
 
 -- Una <Artisan Leatherworker>
 DELETE FROM `npc_trainer` WHERE `ID`=3007;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3007, -380000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3007, -380001);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3007, -380002);
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3007, -380000), (3007, -380001), (3007, -380002);
 
 -- Mak <Journeyman Leatherworker>
 DELETE FROM `npc_trainer` WHERE `ID`=3008;
@@ -62,13 +58,11 @@ INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3008, -380000);
 
 -- Bena Winterhoof <Expert Alchemist>
 DELETE FROM `npc_trainer` WHERE `ID`=3009;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3009, -300000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3009, -300001);
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3009, -300000), (3009, -300001);
 
 -- Teg Dawnstrider <Expert Enchanter>
 DELETE FROM `npc_trainer` WHERE `ID`=3011;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3011, -330000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3011, -330001);
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (3011, -330000), (3011, -330001);
 
 -- Komin Winterhoof
 DELETE FROM `npc_trainer` WHERE `ID`=3013;
@@ -104,29 +98,33 @@ INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11071, -330000);
 
 -- Tarn <Expert Leatherworker>
 DELETE FROM `npc_trainer` WHERE `ID`=11084;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11084, -380000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11084, -380001);
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11084, -380000), (11084, -380001);
 
 
 -- Bena Winterhoof <Expert Alchemist>
 DELETE FROM `gossip_menu_option` WHERE `MenuID`=4128;
-INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES (4128, 0, 3, 'Train me.', 3266, 5, 16);
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES
+(4128, 0, 3, 'Train me.', 3266, 5, 16);
 
 -- Teg Dawnstrider <Expert Enchanter>
 DELETE FROM `gossip_menu_option` WHERE `MenuID`=4165;
-INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES (4165, 0, 3, 'Train me.', 3266, 5, 16);
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES 
+(4165, 0, 3, 'Train me.', 3266, 5, 16);
 
 -- Tarn <Expert Leatherworker>
 DELETE FROM `gossip_menu_option` WHERE `MenuID`=4207;
-INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES (4207, 0, 3, 'Train me.', 3266, 5, 16);
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES 
+(4207, 0, 3, 'Train me.', 3266, 5, 16);
 
 -- Una <Artisan Leatherworker>
 DELETE FROM `gossip_menu_option` WHERE `MenuID`=4242;
-INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES (4242, 0, 3, 'Train me.', 3266, 5, 16);
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES 
+(4242, 0, 3, 'Train me.', 3266, 5, 16);
 
 -- Tepa <Expert Tailor>
 DELETE FROM `gossip_menu_option` WHERE `MenuID`=4351;
-INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES (4351, 0, 3, 'Train me.', 3266, 5, 16);
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES 
+(4351, 0, 3, 'Train me.', 3266, 5, 16);
 
 
 -- Karn Stonehoof <Expert Blacksmith>

--- a/sql/world/base/zone_undercity.sql
+++ b/sql/world/base/zone_undercity.sql
@@ -1,11 +1,3 @@
--- Summon Felsteed (Warlock)
-DELETE FROM `creature_queststarter` WHERE `id`=4563 AND `quest`=4489;
-INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (4563, 4489);
-
--- Mary Edras <First Aid Trainer> 
-DELETE FROM `npc_trainer` WHERE `ID`=4591; 
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (4591, -350000); 
-
 -- Doctor Martin Felben <Journeyman Alchemist Trainer>
 UPDATE `creature_template` SET `subname`='Journeyman Alchemist Trainer', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11044;
 
@@ -30,14 +22,14 @@ UPDATE `creature_template` SET `subname`='Journeyman Tailor', `npcflag`=81, `tra
 -- Rhiannon Davis <Expert Tailor>
 UPDATE `creature_template` SET `subname`='Expert Tailor', `npcflag`=81, `trainer_type`=2, `type_flags`=134217728 WHERE `entry`=11049;
 
+
 -- Doctor Martin Felben <Journeyman Alchemist Trainer>
 DELETE FROM `npc_trainer` WHERE `ID`=11044;
 INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11044, -300000);
 
 -- Doctor Marsh <Expert Alchemist>
 DELETE FROM `npc_trainer` WHERE `ID`=4609;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (4609, -300000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (4609, -300001);
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (4609, -300000), (4609, -300001);
 
 -- Basil Frye <Journeyman Blacksmith>
 DELETE FROM `npc_trainer` WHERE `ID`=4605;
@@ -61,8 +53,7 @@ INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11048, -410000);
 
 -- Rhiannon Davis <Expert Tailor>
 DELETE FROM `npc_trainer` WHERE `ID`=11049;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11049, -410000);
-INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11049, -410001);
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11049, -410000), (11049, -410001);
 
 -- Doctor Marsh <Expert Alchemist>
 DELETE FROM `gossip_menu_option` WHERE `MenuID`=4130;
@@ -104,6 +95,15 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4354 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES 
 (15, 4354, 0, 7, 197, 125, 'Show menu if tailoring is 125 or higher');
+
+
+-- Summon Felsteed (Warlock)
+DELETE FROM `creature_queststarter` WHERE `id`=4563 AND `quest`=4489;
+INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (4563, 4489);
+
+-- Mary Edras <First Aid Trainer> 
+DELETE FROM `npc_trainer` WHERE `ID`=4591; 
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (4591, -350000); 
 
 
 /* Replace orc guards with pre-wrathgate abomination guards */

--- a/sql/world/base/zone_undercity.sql
+++ b/sql/world/base/zone_undercity.sql
@@ -6,6 +6,106 @@ INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (4563, 4489);
 DELETE FROM `npc_trainer` WHERE `ID`=4591; 
 INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (4591, -350000); 
 
+-- Doctor Martin Felben <Journeyman Alchemist Trainer>
+UPDATE `creature_template` SET `subname`='Journeyman Alchemist Trainer', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11044;
+
+-- Doctor Marsh <Expert Alchemist>
+UPDATE `creature_template` SET `subname`='Expert Alchemist', `npcflag`=81, `trainer_type`=2, `type_flags`=134217728 WHERE `entry`=4609;
+
+-- Basil Frye <Journeyman Blacksmith>
+UPDATE `creature_template` SET `subname`='Journeyman Blacksmith', `npcflag`=81, `trainer_type`=2 WHERE `entry`=4605;
+
+-- Malcomb Wynn <Journeyman Enchanter>
+UPDATE `creature_template` SET `subname`='Journeyman Enchanter', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11067;
+
+-- Graham Van Talen <Journeyman Engineer>
+UPDATE `creature_template` SET `subname`='Journeyman Engineer', `npcflag`=81, `trainer_type`=2 WHERE `entry`=4586;
+
+-- Dan Golthas <Journeyman Leatherworker>
+UPDATE `creature_template` SET `subname`='Journeyman Leatherworker', `npcflag`=81, `trainer_type`=2 WHERE `entry`=223;
+
+-- Victor Ward <Journeyman Tailor>
+UPDATE `creature_template` SET `subname`='Journeyman Tailor', `npcflag`=81, `trainer_type`=2 WHERE `entry`=11048;
+
+-- Rhiannon Davis <Expert Tailor>
+UPDATE `creature_template` SET `subname`='Expert Tailor', `npcflag`=81, `trainer_type`=2, `type_flags`=134217728 WHERE `entry`=11049;
+
+-- Doctor Martin Felben <Journeyman Alchemist Trainer>
+DELETE FROM `npc_trainer` WHERE `ID`=11044;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11044, -300000);
+
+-- Doctor Marsh <Expert Alchemist>
+DELETE FROM `npc_trainer` WHERE `ID`=4609;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (4609, -300000);
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (4609, -300001);
+
+-- Basil Frye <Journeyman Blacksmith>
+DELETE FROM `npc_trainer` WHERE `ID`=4605;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (4605, -310000);
+
+-- Malcomb Wynn <Journeyman Enchanter>
+DELETE FROM `npc_trainer` WHERE `ID`=11067;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11067, -330000);
+
+-- Graham Van Talen <Journeyman Engineer>
+DELETE FROM `npc_trainer` WHERE `ID`=4586;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (4586, -340000);
+
+-- Dan Golthas <Journeyman Leatherworker>
+DELETE FROM `npc_trainer` WHERE `ID`=223;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (223, -380000);
+
+-- Victor Ward <Journeyman Tailor>
+DELETE FROM `npc_trainer` WHERE `ID`=11048;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11048, -410000);
+
+-- Rhiannon Davis <Expert Tailor>
+DELETE FROM `npc_trainer` WHERE `ID`=11049;
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11049, -410000);
+INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (11049, -410001);
+
+-- Doctor Marsh <Expert Alchemist>
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=4130;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES
+(4130, 0, 3, 'Train me.', 3266, 5, 16);
+
+-- Rhiannon Davis <Expert Tailor>
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=4352;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`) VALUES 
+(4352, 0, 3, 'Train me.', 3266, 5, 16);
+
+
+-- Doctor Marsh <Expert Alchemist>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4130 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 4130, 0, 7, 171, 50, 'Show menu if alchemy is 50 or higher');
+
+-- James Van Brunt <Expert Blacksmith>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=1022 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(15, 1022, 0, 7, 164, 50, 'Show menu if blacksmithing is 50 or higher');
+
+-- Lavinia Crowe <Expert Enchanter>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4166 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES 
+(15, 4166, 0, 7, 333, 50, 'Show menu if enchanting is 50 or higher');
+
+-- Arthur Moore <Expert Leatherworker>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4210 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES 
+(15, 4210, 0, 7, 165, 50, 'Show menu if leatherworking is 50 or higher');
+
+-- Rhiannon Davis <Expert Tailor>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4352 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES 
+(15, 4352, 0, 7, 197, 50, 'Show menu if tailoring is 50 or higher');
+
+-- Josef Gregorian <Artisan Tailor>
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4354 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=7;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES 
+(15, 4354, 0, 7, 197, 125, 'Show menu if tailoring is 125 or higher');
+
+
 /* Replace orc guards with pre-wrathgate abomination guards */
 UPDATE `creature` SET `id1`=5624, `equipment_id`=0 WHERE `id1`=36213;
 


### PR DESCRIPTION
- This restores many journeyman and expert profession trainers in all the vanilla cities.
- It also fixes an issues with the "Train me" menu not showing up for trainers.
- many batched inserts

This does require a reset of the client's cache files.
