### PR TITLE
Stratholme Fixes

### DIFF
--- a/sql/world/base/zone_stratholme.sql
+++ b/sql/world/base/zone_stratholme.sql
@@ -1,0 +1,3 @@
+-- stratholme living side, 3 doors not locked that should require the scarlet key
+UPDATE gameobject_template SET `Data1` = 299 WHERE `entry` IN (175967, 175968, 176194);
+UPDATE gameobject_template_addon SET `flags` = 34 WHERE `entry` IN (175967, 175968, 176194);


### PR DESCRIPTION
- Stratholme living side, 3 doors not locked that should require the scarlet key
the bastion door (entry 175967)
hoard door (entry 175968)
the high command door (entry 176194)

this fix may require clearing client cache file, gameobjectcache.wdb