### PR TITLE
fix Astor Hadren's Gossip for Deathstalkers quest

### DIFF
--- a/sql/world/base/zone_undercity.sql
+++ b/sql/world/base/zone_undercity.sql
@@ -171,6 +171,9 @@ UPDATE `quest_template` SET `RewardNextQuest` = 1898 WHERE `ID` = 1886;
 UPDATE `quest_template` SET `RewardNextQuest` = 1899 WHERE `ID` = 1898;
 UPDATE `quest_template` SET `RewardNextQuest` = 1978 WHERE `ID` = 1899;
 
+UPDATE `conditions` SET `ConditionValue1`= 1886,  `comment` = 'Astor Hadren - Show gossip if quest 1886 is taken' WHERE `SourceTypeOrReferenceId` = 15 AND `SourceGroup` = 126;
+
+
 /* Restore Varimathras */
 UPDATE `creature` SET `id1`=2425, `equipment_id`=0 WHERE `id1`=36273;
 


### PR DESCRIPTION
related to: https://github.com/ZhengPeiRu21/mod-individual-progression/issues/272 and https://github.com/ZhengPeiRu21/mod-individual-progression/issues/449

gossip did not show up because old quest ID was used