### PR TITLE
fix Blessed Medallion of Karabor key

### DIFF
--- a/sql/world/base/dungeon_attunements.sql
+++ b/sql/world/base/dungeon_attunements.sql
@@ -6,7 +6,11 @@ REPLACE INTO `dungeon_access_requirements` (`dungeon_access_id`, `requirement_ty
 REPLACE INTO `dungeon_access_requirements` (`dungeon_access_id`, `requirement_type`, `requirement_id`, `requirement_note`, `faction`, `priority`, `leader_only`, `comment`) VALUES (47, 1, 10888, 'You must complete "The Trial of the Naaru: Magtheridon" to enter The Eye.', 2, NULL, 0, NULL);
 REPLACE INTO `dungeon_access_requirements` (`dungeon_access_id`, `requirement_type`, `requirement_id`, `requirement_note`, `faction`, `priority`, `leader_only`, `comment`) VALUES (62, 1, 10277, 'You must complete the quest "The Caverns of Time" to enter Old Hillsbrad.', 2, NULL, 0, NULL);
 REPLACE INTO `dungeon_access_requirements` (`dungeon_access_id`, `requirement_type`, `requirement_id`, `requirement_note`, `faction`, `priority`, `leader_only`, `comment`) VALUES (63, 1, 10277, 'You must complete the quest "The Caverns of Time" to enter Old Hillsbrad.', 2, NULL, 0, NULL);
-REPLACE INTO `dungeon_access_requirements` (`dungeon_access_id`, `requirement_type`, `requirement_id`, `requirement_note`, `faction`, `priority`, `leader_only`, `comment`) VALUES (64, 2, 32649, 'You must possess the Medallion of Karabor to enter the Black Temple.', 2, NULL, 0, NULL);
+
+/* Because you should also be able to enter with the blessed Medallion of Karabor, the quest is checked instead of the item. It's not possible to do a check for item 1 or 2. 
+   This way the requirement_note is still correct, you just don't need the item on you anymore. */
+REPLACE INTO `dungeon_access_requirements` (`dungeon_access_id`, `requirement_type`, `requirement_id`, `requirement_note`, `faction`, `priority`, `leader_only`, `comment`) VALUES 
+(64, 1, 10985, 'You must possess the Medallion of Karabor to enter the Black Temple.', 2, NULL, 0, NULL);
 
 /* Maraudon Portal Requirement Script */
 UPDATE `gameobject_template` SET `ScriptName` = 'go_mara_portal' WHERE `entry` = 178404;


### PR DESCRIPTION
related to: https://github.com/ZhengPeiRu21/mod-individual-progression/issues/211

This solves the problem of not being able to enter the black temple with the blessed medallion of Karabor.

Instead, it now checks if the players completed the quest to get the medallion.
This means players still need the medallion, but they don't need it on them anymore.
It's not possible afaik to check for item 1 OR 2.