### PR TITLE
fix Pristine Tigress Fang drop chance

### DIFF
--- a/sql/world/base/zone_stranglethorn.sql
+++ b/sql/world/base/zone_stranglethorn.sql
@@ -1,0 +1,2 @@
+/* Drop chance for Pristine Tigress Fang was incorrectly set to 100 - updated to 4 */
+UPDATE `creature_loot_template` SET `Chance` = 4 WHERE `Item` = 3839 AND `Entry` = 772;


### PR DESCRIPTION
chance was 100%
now set to 4%,