### PR TITLE
new AQ war effort scripts

### DIFF
--- a/sql/world/base/zone_ironforge.sql
+++ b/sql/world/base/zone_ironforge.sql
@@ -122,3 +122,13 @@ INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (5172, 4487);
 -- Nissa Firestone <First Aid Trainer> 
 DELETE FROM `npc_trainer` WHERE `ID`=5150; 
 INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5150, -350000); 
+
+-- Show AQ war effort objects during pre-AQ phase (this will probably be moved to separate sql)
+DELETE FROM `gameobject` WHERE `id` IN (180598, 180679, 180680, 180681);
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, 
+    `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`, `Comment`) VALUES 
+
+(29294, 180598, 0, 0, 0, 1, 1, -4971.55, -1148.57, 501.648, 2.28638, 0, 0, 0.909961, 0.414693, 180, 100, 1, 'gobject_ipp_we', 0, NULL),
+(29299, 180681, 0, 0, 0, 1, 1, -4958.51, -1179.32, 501.659, 2.26893, 0, 0, 0.906308, 0.422618, 180, 100, 1, 'gobject_ipp_we', 0, NULL),
+(29300, 180680, 0, 0, 0, 1, 1, -4913.85, -1226, 501.651, 2.25148, 0, 0, 0.902585, 0.430511, 180, 100, 1, 'gobject_ipp_we', 0, NULL),
+(29301, 180679, 0, 0, 0, 1, 1, -4937.29, -1282.74, 501.672, 2.26893, 0, 0, 0.906308, 0.422618, 180, 100, 1, 'gobject_ipp_we', 0, NULL);

--- a/sql/world/base/zone_ironforge.sql
+++ b/sql/world/base/zone_ironforge.sql
@@ -122,13 +122,3 @@ INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (5172, 4487);
 -- Nissa Firestone <First Aid Trainer> 
 DELETE FROM `npc_trainer` WHERE `ID`=5150; 
 INSERT INTO `npc_trainer` (`ID`, `SpellID`) VALUES (5150, -350000); 
-
--- Show AQ war effort objects during pre-AQ phase (this will probably be moved to separate sql)
-DELETE FROM `gameobject` WHERE `id` IN (180598, 180679, 180680, 180681);
-INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, 
-    `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`, `Comment`) VALUES 
-
-(29294, 180598, 0, 0, 0, 1, 1, -4971.55, -1148.57, 501.648, 2.28638, 0, 0, 0.909961, 0.414693, 180, 100, 1, 'gobject_ipp_we', 0, NULL),
-(29299, 180681, 0, 0, 0, 1, 1, -4958.51, -1179.32, 501.659, 2.26893, 0, 0, 0.906308, 0.422618, 180, 100, 1, 'gobject_ipp_we', 0, NULL),
-(29300, 180680, 0, 0, 0, 1, 1, -4913.85, -1226, 501.651, 2.25148, 0, 0, 0.902585, 0.430511, 180, 100, 1, 'gobject_ipp_we', 0, NULL),
-(29301, 180679, 0, 0, 0, 1, 1, -4937.29, -1282.74, 501.672, 2.26893, 0, 0, 0.906308, 0.422618, 180, 100, 1, 'gobject_ipp_we', 0, NULL);

--- a/src/IndividualProgressionAwarenessScripts.cpp
+++ b/src/IndividualProgressionAwarenessScripts.cpp
@@ -104,6 +104,41 @@ public:
     }
 };
 
+class gobject_ipp_we : public GameObjectScript
+{
+public:
+    gobject_ipp_we() : GameObjectScript("gobject_ipp_we") { }
+
+    struct gobject_ipp_weAI: GameObjectAI
+    {
+        explicit gobject_ipp_weAI(GameObject* object) : GameObjectAI(object) { };
+
+        bool CanBeSeen(Player const* player) override
+        {
+            if (player->IsGameMaster() || !sIndividualProgression->enabled)
+            {
+                return true;
+            }
+            
+            Player* target = ObjectAccessor::FindConnectedPlayer(player->GetGUID());
+            
+            if (sIndividualProgression->hasPassedProgression(target, PROGRESSION_PRE_AQ))
+            {
+                return sIndividualProgression->isBeforeProgression(target, PROGRESSION_PRE_AQ);
+            }
+            else
+            {
+                return sIndividualProgression->hasPassedProgression(target, PROGRESSION_BLACKWING_LAIR);
+            }
+        }
+    };
+
+    GameObjectAI* GetAI(GameObject* object) const override
+    {
+        return new gobject_ipp_weAI(object);
+    }
+};
+
 class npc_ipp_tbc_t4 : public CreatureScript
 {
 public:
@@ -312,6 +347,41 @@ public:
     }
 };
 
+class npc_ipp_we : public CreatureScript
+{
+public:
+    npc_ipp_we() : CreatureScript("npc_ipp_we") { }
+
+    struct npc_ipp_weAI: ScriptedAI
+    {
+        explicit npc_ipp_weAI(Creature* creature) : ScriptedAI(creature) { };
+
+        bool CanBeSeen(Player const* player) override
+        {
+            if (player->IsGameMaster() || !sIndividualProgression->enabled)
+            {
+                return true;
+            }
+			
+            Player* target = ObjectAccessor::FindConnectedPlayer(player->GetGUID());
+			
+            if (sIndividualProgression->hasPassedProgression(target, PROGRESSION_PRE_AQ))
+            {
+                return sIndividualProgression->isBeforeProgression(target, PROGRESSION_PRE_AQ);
+            }
+            else
+            {
+                return sIndividualProgression->hasPassedProgression(target, PROGRESSION_BLACKWING_LAIR);
+            }			
+        }
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new npc_ipp_weAI(creature);
+    }
+};
+
 class npc_ipp_ds2 : public CreatureScript
 {
 public:
@@ -370,6 +440,7 @@ public:
 // Add all scripts in one
 void AddSC_mod_individual_progression_awareness()
 {
+    new npc_ipp_we(); // aq war effort
     new npc_ipp_aq();
 //    new npc_ipp_naxx40(); // Not used yet
     new npc_ipp_ds2();
@@ -383,5 +454,6 @@ void AddSC_mod_individual_progression_awareness()
     new npc_ipp_wotlk_icc();
     new gobject_ipp_tbc();
     new gobject_ipp_aq();
+    new gobject_ipp_we(); // aq war effort
 //    new gobject_ipp_wotlk(); // Not used yet
 }


### PR DESCRIPTION
npc_ipp_we and gobject_ipp_we

to show npcs and game objects only during the pre-aq phase. they disappear again after.
scripts that aren't used need to be commented out to prevent a worldserver console error when starting up the server.

still need to find out if we need the game object script.
