### PR TITLE
Optional vanilla phasing

### DIFF
--- a/sql/world/base/ipp_aware_npcs.sql
+++ b/sql/world/base/ipp_aware_npcs.sql
@@ -13,12 +13,15 @@ UPDATE `creature` SET `ScriptName` = 'npc_ipp_aq' WHERE `id1` = 15184 AND `guid`
 -- Phasing Wanted Poster Deathclasp
 UPDATE `gameobject_template` SET `ScriptName` = 'gobject_ipp_aq' WHERE `entry` IN (180448);
 
--- Lights Hope Chapel
+-- Lights Hope Chapel - npcs
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_naxx40' WHERE `entry` IN (11102, 16112, 16113, 16114, 16115, 16116, 16131, 16132, 16133, 16134, 16135,  
                                                                                  16212, 16225, 16228, 16229, 16256, 16283, 16284, 16376, 16378, 17069, 17072);
 -- undo previous method of phasing (this can be removed later on)
 UPDATE `creature` SET `phaseMask` = 1 WHERE `id1` IN (11102, 16112, 16113, 16114, 16115, 16116, 16131, 16132, 16133, 16134, 16135,  
                                                       16212, 16225, 16228, 16229, 16256, 16283, 16284, 16376, 16378, 17069, 17072);
+
+-- Lights Hope Chapel - gobjects
+UPDATE `gameobject` SET `ScriptName` = 'gobject_ipp_naxx40' WHERE `guid` IN (45603, 45606, 45607, 45764, 45765, 45766, 45767, 45768, 45769, 45770, 45771, 45838, 45839, 45840);
 
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_wotlk' WHERE `entry` IN (28602, 29611, 34084);
 

--- a/sql/world/base/ipp_aware_npcs.sql
+++ b/sql/world/base/ipp_aware_npcs.sql
@@ -17,8 +17,8 @@ UPDATE `gameobject_template` SET `ScriptName` = 'gobject_ipp_aq' WHERE `entry` I
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_naxx40' WHERE `entry` IN (11102, 16112, 16113, 16114, 16115, 16116, 16131, 16132, 16133, 16134, 16135,  
                                                                                  16212, 16225, 16228, 16229, 16256, 16283, 16284, 16376, 16378, 17069, 17072);
 -- undo previous method of phasing (this can be removed later on)
-UPDATE `creature` SET `phaseMask` = 1 WHERE `entry` IN (11102, 16112, 16113, 16114, 16115, 16116, 16131, 16132, 16133, 16134, 16135,  
-                                                        16212, 16225, 16228, 16229, 16256, 16283, 16284, 16376, 16378, 17069, 17072);
+UPDATE `creature` SET `phaseMask` = 1 WHERE `id1` IN (11102, 16112, 16113, 16114, 16115, 16116, 16131, 16132, 16133, 16134, 16135,  
+                                                      16212, 16225, 16228, 16229, 16256, 16283, 16284, 16376, 16378, 17069, 17072);
 
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_wotlk' WHERE `entry` IN (28602, 29611, 34084);
 

--- a/sql/world/base/ipp_aware_npcs.sql
+++ b/sql/world/base/ipp_aware_npcs.sql
@@ -1,5 +1,3 @@
-SET @IPPPHASE := 65536;
-
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc' WHERE `entry` IN (16841, 19254, 16840,
                                                                               20026, 20027, 20053, 20054, 20069, 18542, 20080, 20081, 20082, 21643, 20130,
                                                                               19934, 19936, 19950, 19951, 19959, 22889, 22902, 22835, 22837);
@@ -15,11 +13,12 @@ UPDATE `creature` SET `ScriptName` = 'npc_ipp_aq' WHERE `id1` = 15184 AND `guid`
 -- Phasing Wanted Poster Deathclasp
 UPDATE `gameobject_template` SET `ScriptName` = 'gobject_ipp_aq' WHERE `entry` IN (180448);
 
-# Light's Hope Chapel
-UPDATE `creature` SET `phaseMask` = @IPPPHASE WHERE `id1` IN (11102, 16113, 16112, 16115, 16116, 16131, 16132, 16133, 16134, 16135, 16114, 16376, 16212, 16225, 16228, 16229,
-                                                                                 16256, 16283, 16284, 16378, 17069, 17072);
-# The above query adds one undesired creature (Pack Mule, 16225) to the phasing, so put it back to normal 
-UPDATE `creature` SET `phaseMask` = 1 WHERE `guid` = 56932;
+-- Lights Hope Chapel
+UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_naxx40' WHERE `entry` IN (11102, 16112, 16113, 16114, 16115, 16116, 16131, 16132, 16133, 16134, 16135,  
+                                                                                 16212, 16225, 16228, 16229, 16256, 16283, 16284, 16376, 16378, 17069, 17072);
+-- undo previous method of phasing (this can be removed later on)
+UPDATE `creature` SET `phaseMask` = 1 WHERE `entry` IN (11102, 16112, 16113, 16114, 16115, 16116, 16131, 16132, 16133, 16134, 16135,  
+                                                        16212, 16225, 16228, 16229, 16256, 16283, 16284, 16376, 16378, 17069, 17072);
 
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_wotlk' WHERE `entry` IN (28602, 29611, 34084);
 
@@ -27,7 +26,7 @@ UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_wotlk_ulduar' WHERE `entr
 
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_wotlk_totc' WHERE `entry` IN (35498, 35577, 35496, 36208, 35500, 35497, 34244, 28701);
 
-# TODO: Harold Winston (32172) has rings from all patches, so he needs special phasing applied - for now make him require ICC progression
+-- TODO: Harold Winston (32172) has rings from all patches, so he needs special phasing applied - for now make him require ICC progression
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_wotlk_icc' WHERE `entry` IN (37776, 40160, 37780, 32172);
 
 -- Hide the portals to Blasted Lands until TBC is unlocked
@@ -41,11 +40,10 @@ UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_wotlk' WHERE `entry` IN (
 
 -- Phasing Isle of Conquest Emissary and banner until WotLK
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_wotlk' WHERE `entry` IN (34948, 34950);
-UPDATE `gameobject_template` SET `ScriptName` = 'gobject_ipp_wotlk' WHERE `entry` = 195533;
+UPDATE `gameobject_template` SET `ScriptName` = 'gobject_ipp_wotlk' WHERE `entry` IN (195532, 195533);
 
 -- Drop source for 2.3 Jewelcrafting Recipe
--- disabled phasing for now to prevent the creature from attacking while phased
-UPDATE `creature_template` SET `ScriptName` = '' WHERE `entry` = 19768;
+UPDATE `creature_template` SET `ScriptName` = '' WHERE `entry` = 19768; -- disabled for now to prevent the creature from attacking while phased
 
 -- Phasing Zul'Aman quest npcs until TBC T4.
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc_t4' WHERE `entry` IN (19227, 23761);
@@ -57,6 +55,7 @@ UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc_t4' WHERE `entry` IN 
 UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc_t5' WHERE `entry` IN (25167, 18594);
 
 -- Argent Tournament
+SET @IPPPHASE := 65536;
 UPDATE `creature` SET `phaseMask` = @IPPPHASE WHERE `guid` IN (25, 63129, 63236, 63370, 63371, 65274, 65275, 65283, 65284, 65285, 65325, 65327, 65350, 65351, 65371, 65451,
 65522, 65523, 65526, 65901, 66478, 66479, 66741, 66753, 66788, 66790, 66792, 66910, 66941, 67185, 67187, 68005, 68457, 68583, 68906, 68941, 68947, 68987, 68989, 68990, 69010,
 69011, 69065, 69077, 69078, 69880, 69973, 69976, 69990, 69992, 69995, 69996, 70000, 70001, 70002, 70003, 70005, 70006, 70007, 70178, 70179, 70180, 70181, 70448, 70539, 70548,

--- a/sql/world/base/optional_vanilla_phasing.sql
+++ b/sql/world/base/optional_vanilla_phasing.sql
@@ -27,8 +27,5 @@ UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_naxx40' WHERE `entry` IN 
 16227 -- Bragok, Ratchet
 );
 
--- phase Flight Path objects
-UPDATE `gameobject` SET `ScriptName` = 'gobject_ipp_naxx40' WHERE `guid` IN (51272, 51679, 51688, 51944, 54765, 54783, 54796, 54857);
-
 -- remove interactions between Cersei, Lorrin and the orcs in Stonard 
 UPDATE `creature_template` SET `AIName` = '' WHERE `entry` IN (12807, 17109, 27705);

--- a/sql/world/base/optional_vanilla_phasing.sql
+++ b/sql/world/base/optional_vanilla_phasing.sql
@@ -2,7 +2,7 @@
     This includes quest givers and flight paths. 
 */
 
-UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_wotlk' WHERE `entry` IN (
+UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_tbc' WHERE `entry` IN (
 16288, -- Advisor Sorrelon, The Sepulcher
 17092, -- Advisor Duskingdawn, Tarren Mill
 17093, -- Magistrix Elosai, Freewind Post

--- a/sql/world/base/optional_vanilla_phasing.sql
+++ b/sql/world/base/optional_vanilla_phasing.sql
@@ -1,0 +1,35 @@
+/*  This will phase Vanilla/TBC npcs & objects placed in vanilla areas until they were originally added to the game.
+    This includes quest givers and flight paths. 
+*/
+
+UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_wotlk' WHERE `entry` IN (
+16288, -- Advisor Sorrelon, The Sepulcher
+17092, -- Advisor Duskingdawn, Tarren Mill
+17093, -- Magistrix Elosai, Freewind Post
+17094, -- Nemeth Hawkeye, Grom'gol Base Camp
+17095, -- Balandar Brightstar, Brackenwall Village
+17097, -- Advisor Sarophas, Kargath
+17106, -- Vindicator Palanaar, Astranaar
+17109, -- Cersei Dusksinger, Stonard
+17119, -- Ithania, North Point Tower
+17194, -- Anchorite Delan, Darkshire
+17218, -- Huraan, Southshore
+17223, -- Ambassador Rualeth, Aerie Peak
+22931, -- Gorrim, Emerald Sanctuary
+24366, -- Nizzle, Rebel Camp
+27705, -- Lorrin Foxfire, Stonard
+37888, -- Frax Bucketdrop, Thondroril River
+37915 -- Timothy Cunningham, The Bulwark
+);
+
+UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_naxx40' WHERE `entry` IN (
+10583, -- Gryfe, Marshal's Refuge
+16227 -- Bragok, Ratchet
+);
+
+-- phase Flight Path objects
+UPDATE `gameobject` SET `ScriptName` = 'gobject_ipp_naxx40' WHERE `guid` IN (51272, 51679, 51688, 51944, 54765, 54783, 54796, 54857);
+
+
+
+-- todo: remove interactions between Cersei, Lorrin and the orcs in Stonard 

--- a/sql/world/base/optional_vanilla_phasing.sql
+++ b/sql/world/base/optional_vanilla_phasing.sql
@@ -30,6 +30,5 @@ UPDATE `creature_template` SET `ScriptName` = 'npc_ipp_naxx40' WHERE `entry` IN 
 -- phase Flight Path objects
 UPDATE `gameobject` SET `ScriptName` = 'gobject_ipp_naxx40' WHERE `guid` IN (51272, 51679, 51688, 51944, 54765, 54783, 54796, 54857);
 
-
-
--- todo: remove interactions between Cersei, Lorrin and the orcs in Stonard 
+-- remove interactions between Cersei, Lorrin and the orcs in Stonard 
+UPDATE `creature_template` SET `AIName` = '' WHERE `entry` IN (12807, 17109, 27705);

--- a/src/IndividualProgressionAwarenessScripts.cpp
+++ b/src/IndividualProgressionAwarenessScripts.cpp
@@ -104,6 +104,32 @@ public:
     }
 };
 
+class gobject_ipp_naxx40 : public GameObjectScript
+{
+public:
+    gobject_ipp_naxx40() : GameObjectScript("gobject_ipp_naxx40") { }
+
+    struct gobject_ipp_naxx40AI: GameObjectAI
+    {
+        explicit gobject_ipp_naxx40AI(GameObject* object) : GameObjectAI(object) { };
+
+        bool CanBeSeen(Player const* player) override
+        {
+            if (player->IsGameMaster() || !sIndividualProgression->enabled)
+            {
+                return true;
+            }
+            Player* target = ObjectAccessor::FindConnectedPlayer(player->GetGUID());
+            return sIndividualProgression->hasPassedProgression(target, PROGRESSION_AQ);
+        }
+    };
+
+    GameObjectAI* GetAI(GameObject* object) const override
+    {
+        return new gobject_ipp_naxx40AI(object);
+    }
+};
+
 class gobject_ipp_we : public GameObjectScript
 {
 public:
@@ -442,7 +468,7 @@ void AddSC_mod_individual_progression_awareness()
 {
     new npc_ipp_we(); // aq war effort
     new npc_ipp_aq();
-//    new npc_ipp_naxx40(); // Not used yet
+    new npc_ipp_naxx40();
     new npc_ipp_ds2();
     new npc_ipp_tbc();
     new npc_ipp_tbc_t4();
@@ -455,5 +481,6 @@ void AddSC_mod_individual_progression_awareness()
     new gobject_ipp_tbc();
     new gobject_ipp_aq();
     new gobject_ipp_we(); // aq war effort
-//    new gobject_ipp_wotlk(); // Not used yet
+    new gobject_ipp_naxx40();
+    //    new gobject_ipp_wotlk(); // Not used yet
 }

--- a/src/IndividualProgressionAwarenessScripts.cpp
+++ b/src/IndividualProgressionAwarenessScripts.cpp
@@ -482,5 +482,5 @@ void AddSC_mod_individual_progression_awareness()
     new gobject_ipp_aq();
     new gobject_ipp_we(); // aq war effort
     new gobject_ipp_naxx40();
-    //    new gobject_ipp_wotlk(); // Not used yet
+    new gobject_ipp_wotlk();
 }


### PR DESCRIPTION
Related to: https://github.com/ZhengPeiRu21/mod-individual-progression/issues/470 and https://github.com/ZhengPeiRu21/mod-individual-progression/issues/148

This optional SQL will phase Vanilla/TBC npcs & objects placed in vanilla areas until they were originally added to the game.
This includes quest givers and flight paths. Yes, also the flight paths in Ratchet and Marshals Refuge.

Mudsprocket has not been touched. Maybe it should be, but then we have a ghost town. That wouldn't be accurate either.

Also changed the method of Naxx phasing to how it's done for the rest.

I need to test all of this first.