### PR TITLE
Clear missing item ID error's

### DIFF
--- a/data/sql/world/updates/badges-of-justice.sql
+++ b/data/sql/world/updates/badges-of-justice.sql
@@ -1,13 +1,13 @@
 -- Tempest Keep bosses
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Chance`, `GroupId`, `MinCount`, `MaxCount`) VALUES
-(18805, 29434, 100, 1, 1, 1),  -- High Astromancer Solarian
-(19516, 29434, 100, 1, 1, 1),  -- Void Reaver
-(19622, 29434, 100, 1, 1, 2),  -- Kael'thas
+(18805, 29434, 100, 0, 1, 1),  -- High Astromancer Solarian
+(19516, 29434, 100, 0, 1, 1),  -- Void Reaver
+(19622, 29434, 100, 0, 1, 2),  -- Kael'thas
 
 -- Serpentshrine Cavern bosses
-(21212, 29434, 100, 1, 1, 1),  -- Lady Vashj
-(21213, 29434, 100, 1, 1, 1),  -- Morogrim Tidewalker
-(21214, 29434, 100, 1, 1, 1),  -- Fathom-Lord Karathress
-(21215, 29434, 100, 1, 1, 1),  -- Leotheras the Blind
-(21216, 29434, 100, 1, 1, 1),  -- Hydross the Unstable
-(21217, 29434, 100, 1, 1, 1);  -- The Lurker Below
+(21212, 29434, 100, 0, 1, 1),  -- Lady Vashj
+(21213, 29434, 100, 0, 1, 1),  -- Morogrim Tidewalker
+(21214, 29434, 100, 0, 1, 1),  -- Fathom-Lord Karathress
+(21215, 29434, 100, 0, 1, 1),  -- Leotheras the Blind
+(21216, 29434, 100, 0, 1, 1),  -- Hydross the Unstable
+(21217, 29434, 100, 0, 1, 1);  -- The Lurker Below


### PR DESCRIPTION
This single SQL inserts into the creature_loot_template to correct the error's displayed when server launches.

ItemID: 29434

Boss/LootID:
18805
19516
19622
21212
21213
21214
21215
21216
21217