### PR TITLE
Solve archmage quests

### DIFF
--- a/data/sql/world/base/zone_dalaran.sql
+++ b/data/sql/world/base/zone_dalaran.sql
@@ -91,13 +91,72 @@ INSERT INTO `creature_questender` (`id`, `quest`) VALUES
 (31439, 13255),
 (31439, 13256);
 
--- Archmage Lan'dalock / Proof of Demise: The Black Knight
-DELETE FROM `creature_queststarter` WHERE `id` = 20735 AND `quest` = 14199;
-INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (20735, 14199);
-DELETE FROM `creature_questender` WHERE `id` = 20735 AND `quest` = 14199;
-INSERT INTO `creature_questender` (`id`, `quest`) VALUES (20735, 14199);
+-- Archmage Lan'dalock: between patch 3.3 - patch 3.4 now handles the daily quests. from 3.4 onwards he gives weekly quests.
+DELETE FROM `creature_template` WHERE `entry` = 120735;
+INSERT INTO `creature_template` (`entry`, `difficulty_entry_1`, `difficulty_entry_2`, `difficulty_entry_3`, `KillCredit1`, `KillCredit2`, `name`, `subname`, `IconName`, `gossip_menu_id`, 
+`minlevel`, `maxlevel`, `exp`, `faction`, `npcflag`, `speed_walk`, `speed_run`, `speed_swim`, `speed_flight`, `detection_range`, `rank`, `dmgschool`, `DamageModifier`, 
+`BaseAttackTime`, `RangeAttackTime`, `BaseVariance`, `RangeVariance`, `unit_class`, `unit_flags`, `unit_flags2`, `dynamicflags`, `family`, `type`, `type_flags`, `lootid`, `pickpocketloot`, `skinloot`, 
+`PetSpellDataId`, `VehicleId`, `mingold`, `maxgold`, `AIName`, `MovementType`, `HoverHeight`, `HealthModifier`, `ManaModifier`, `ArmorModifier`, `ExperienceModifier`, `RacialLeader`, `movementId`, 
+`RegenHealth`, `CreatureImmunitiesId`, `flags_extra`, `ScriptName`, `VerifiedBuild`) VALUES
+--
+(120735,0,0,0,0,0,'Archmage Lan\'dalock',NULL,NULL,10061,80,80,2,2007,3,1,1.14286,1,1,20,1,0,4.6,2000,2000,1,1,8,33536,2048,0,0,7,0,0,0,0,0,0,0,0,'',1,1,10,10,1,1,0,0,1,0,2,'',0);
 
-UPDATE `quest_template` SET `Flags` = 4232 WHERE `ID` IN (13245, 13246, 13247, 13248, 13249, 13250, 13251, 13252, 13253, 13254, 13255, 13256, 14199);
+UPDATE `creature_template` SET `ScriptName` = 'npc_archmage_landalock_3_3' WHERE `entry` = 120735;
+UPDATE `creature_template` SET `ScriptName` = 'npc_archmage_landalock_3_4' WHERE `entry` = 20735;
+
+DELETE FROM `creature` WHERE `guid` = 620553;
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, 
+`wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
+(620553, 120735, 571, 0, 0, 1, 1, 1, 5697.56, 576.957, 653.806, 4.24115, 300, 0, 0, 1, 88140, 0, 0, 0, 0, '', 0, 0, NULL);
+
+DELETE FROM `creature_template_locale` WHERE `entry` = 120735;
+INSERT INTO `creature_template_locale` (`entry`, `locale`, `Name`, `Title`, `VerifiedBuild`) VALUES
+(120735, 'deDE', 'Erzmagier Lan\'dalock', '', 18019),
+(120735, 'esES', 'Archimago Lan\'dalock', '', 18019),
+(120735, 'esMX', 'Archimago Lan\'dalock', '', 18019),
+(120735, 'frFR', 'Archimage Lan\'dalock', '', 18019),
+(120735, 'koKR', '대마법사 랜달록', '', 18019),
+(120735, 'ruRU', 'Верховный маг Лан\'далок', '', 18019),
+(120735, 'zhCN', '大法师兰达洛克', '', 18019),
+(120735, 'zhTW', '大法師朗達拉克', '', 18019);
+
+DELETE FROM `creature_template_model` WHERE `CreatureID` = 120735;
+INSERT INTO `creature_template_model` (`CreatureID`, `Idx`, `CreatureDisplayID`, `DisplayScale`, `Probability`, `VerifiedBuild`) VALUES
+(120735, 0, 19744, 1, 1, 51831);
+
+DELETE FROM `creature_queststarter` WHERE `id` = 120735;
+INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES
+(120735, 13245),
+(120735, 13246),
+(120735, 13247),
+(120735, 13248),
+(120735, 13249),
+(120735, 13250),
+(120735, 13251),
+(120735, 13252),
+(120735, 13253),
+(120735, 13254),
+(120735, 13255),
+(120735, 13256),
+(120735, 14199);
+
+DELETE FROM `creature_questender` WHERE `id` = 120735;
+INSERT INTO `creature_questender` (`id`, `quest`) VALUES
+(120735, 13245),
+(120735, 13246),
+(120735, 13247),
+(120735, 13248),
+(120735, 13249),
+(120735, 13250),
+(120735, 13251),
+(120735, 13252),
+(120735, 13253),
+(120735, 13254),
+(120735, 13255),
+(120735, 13256),
+(120735, 14199);
+
+UPDATE `quest_template` SET `Flags` = 4232 WHERE `ID` IN (13245, 13246, 13247, 13248, 13249, 13250, 13251, 13252, 13253, 13254, 13255, 13256, 14199); -- set daily quest
 
 UPDATE `quest_template` SET
 `LogDescription` = 'Archmage Timear in Dalaran wants you to return with the Axe of the Plunderer.$B$BThis quest may only be completed on Heroic difficulty.',
@@ -159,7 +218,7 @@ UPDATE `quest_template` SET
 `QuestCompletionLog` = 'Return to Archmage Timear in Dalaran.'
 WHERE `ID` = 13256;
 
-UPDATE `quest_template` SET `Flags` = 32968,
+UPDATE `quest_template` SET
 `LogDescription` = 'Archmage Lan\'dalock in Dalaran wants you to return with a Fragment of the Black Knight\'s Soul.$B$BThis quest may only be completed on Heroic difficulty.',
 `QuestDescription` = 'My counterpart, Archmage Timear, has asked me to warn you of something dire. Soon, you will be participating in the Trial of the Champions at the Argent Coliseum in Icecrown. You must beware of interference from one known only as the Black Knight.$B$BBring me a fragment of his soul that the Kirin Tor will know he is dealt with. I am told that failing to do so will be your own undoing.',
 `QuestCompletionLog` = 'Return to Archmage Lan\'dalock in Dalaran.'
@@ -170,10 +229,6 @@ UPDATE `quest_offer_reward` SET `RewardText` = '<Archmage Lan\'dalock breathes a
 UPDATE `quest_offer_reward` SET `RewardText` = 'What horrors you must have faced while traversing the Upper City.$b$b<Lan\'dalock glances down at the tarnished crown clutched in your fist.>$b$bPerhaps we should put that aside for their new king whenever the nerubians decide to coronate one?' WHERE `ID` = 13254;
 UPDATE `quest_request_items` SET `CompletionText` = 'Did the Black Knight appear unexpectedly as Timear foresaw?' WHERE `ID` = 14199;
 UPDATE `quest_template_addon` SET `ExclusiveGroup` = 24579 WHERE `ID` = 14199;
-
-DELETE FROM `pool_quest` WHERE `entry` = 14199;
-INSERT INTO `pool_quest` (`entry`, `pool_entry`, `description`) VALUES
-(14199, 5678, 'Proof of Demise: The Black Knight');
 
 DELETE FROM `pool_template` WHERE `entry` = 90000;
 INSERT INTO `pool_template` (`entry`, `max_limit`, `description`) VALUES
@@ -192,7 +247,8 @@ INSERT INTO `pool_quest` (`entry`, `pool_entry`, `description`) VALUES
 (13253, 90000, 'Proof of Demise: Loken'),
 (13254, 90000, 'Proof of Demise: Anub\'arak'),
 (13255, 90000, 'Proof of Demise: Herald Volazj'),
-(13256, 90000, 'Proof of Demise: Cyanigosa');
+(13256, 90000, 'Proof of Demise: Cyanigosa'),
+(14199, 90000, 'Proof of Demise: The Black Knight');
 
 DELETE FROM `creature_template_addon` WHERE `entry` = 31618; -- Keristrasza Image
 INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES

--- a/src/wotlkScripts/npc_archmage_timear.cpp
+++ b/src/wotlkScripts/npc_archmage_timear.cpp
@@ -4,7 +4,8 @@
 #include "ScriptedGossip.h"
 #include "IndividualProgression.h"
 
-enum ArchmageTimearQuests
+// Archmage Timear offered daily quests during WotLK until patch 3.3. After that Archmage Landalock handled the daily quests until patch 3.4.
+enum ArchmageTimearDailyQuests
 {
     QUEST_PROOF_OF_DEMISE_INGVAR_THE_PLUNDERER = 13245,
     QUEST_PROOF_OF_DEMISE_KERISTRASZA = 13246,
@@ -17,10 +18,11 @@ enum ArchmageTimearQuests
     QUEST_PROOF_OF_DEMISE_LOKEN = 13253,
     QUEST_PROOF_OF_DEMISE_ANUB_ARAK = 13254,
     QUEST_PROOF_OF_DEMISE_HERALD_VOLAZJ = 13255,
-    QUEST_PROOF_OF_DEMISE_CYANIGOSA = 13256
+    QUEST_PROOF_OF_DEMISE_CYANIGOSA = 13256,
+    QUEST_PROOF_OF_DEMISE_THE_BLACK_KNIGHT = 14199
 };
 
-enum ArchmageTimearImages
+enum ArchmageTimearDailyImages
 {
     NPC_INGVAR_THE_PLUNDERER_IMAGE = 31584,
     NPC_KERISTRASZA_IMAGE = 31618,
@@ -33,15 +35,14 @@ enum ArchmageTimearImages
     NPC_LOKEN_IMAGE = 31625,
     NPC_ANUB_ARAK_IMAGE = 31626,
     NPC_HERALD_VOLAZJ_IMAGE = 31627,
-    NPC_CYANIGOSA_IMAGE = 31629
+    NPC_CYANIGOSA_IMAGE = 31629,
+    NPC_THE_BLACK_KNIGHT_IMAGE = 35461
 };
 
 class npc_archmage_timear : public CreatureScript
 {
 public:
-    npc_archmage_timear() : CreatureScript("npc_archmage_timear")
-    {
-    }
+    npc_archmage_timear() : CreatureScript("npc_archmage_timear") { }
 
     CreatureAI* GetAI(Creature* creature) const override
     {
@@ -54,6 +55,15 @@ public:
         {
             _switchImageTimer = MINUTE * IN_MILLISECONDS;
             _summonGUID.Clear();
+        }
+
+        bool CanBeSeen(Player const* player) override
+        {
+            if (player->IsGameMaster())
+                return true;
+
+            Player* target = ObjectAccessor::FindConnectedPlayer(player->GetGUID());
+            return sIndividualProgression->isBeforeProgression(target, PROGRESSION_WOTLK_TIER_2);
         }
 
         uint32 GetImageEntry(uint32 QuestId)
@@ -131,7 +141,8 @@ public:
     };
 };
 
-enum ArchmageLandalockQuests
+// After WotLK patch 3.4 Archmange Landalock ONLY offered weekly quests. The weekly quests replaced the daily quests.
+enum ArchmageLandalockWeeklyQuests
 {
     QUEST_SARTHARION_MUST_DIE               = 24579,
     QUEST_ANUBREKHAN_MUST_DIE               = 24580,
@@ -145,10 +156,9 @@ enum ArchmageLandalockQuests
     QUEST_XT_002_DECONSTRUCTOR_MUST_DIE     = 24588,
     QUEST_LORD_JARAXXUS_MUST_DIE            = 24589,
     QUEST_LORD_MARROWGAR_MUST_DIE           = 24590,
-    QUEST_PROOF_OF_DEMISE_THE_BLACK_KNIGHT  = 14199
 };
 
-enum ArchmageLandalockImages
+enum ArchmageLandalockWeeklyImages
 {
     NPC_SARTHARION_IMAGE                = 37849,
     NPC_ANUBREKHAN_IMAGE                = 37850,
@@ -161,25 +171,128 @@ enum ArchmageLandalockImages
     NPC_IGNIS_THE_FURNACE_MASTER_IMAGE  = 37859,
     NPC_XT_002_DECONSTRUCTOR_IMAGE      = 37861,
     NPC_LORD_JARAXXUS_IMAGE             = 37862,
-    NPC_LORD_MARROWGAR_IMAGE            = 37864,
-    NPC_THE_BLACK_KNIGHT_IMAGE          = 35461
+    NPC_LORD_MARROWGAR_IMAGE            = 37864
 };
 
-class npc_archmage_landalock_ipp : public CreatureScript
+class npc_archmage_landalock_ipp_3_3 : public CreatureScript
 {
 public:
-    npc_archmage_landalock_ipp() : CreatureScript("npc_archmage_landalock")
-    {
-    }
+    npc_archmage_landalock_ipp_3_3() : CreatureScript("npc_archmage_landalock_3_3") { }
 
     CreatureAI* GetAI(Creature* creature) const override
     {
-        return new npc_archmage_landalock_ippAI(creature);
+        return new npc_archmage_landalockAI(creature);
     }
 
-    struct npc_archmage_landalock_ippAI : public ScriptedAI
+    struct npc_archmage_landalockAI : public ScriptedAI
     {
-        npc_archmage_landalock_ippAI(Creature* creature) : ScriptedAI(creature)
+        npc_archmage_landalockAI(Creature* creature) : ScriptedAI(creature)
+        {
+            _switchImageTimer = MINUTE * IN_MILLISECONDS;
+            _summonGUID.Clear();
+        }
+
+        bool CanBeSeen(Player const* player) override
+        {
+            if (player->IsGameMaster())
+                return true;
+
+            Player* target = ObjectAccessor::FindConnectedPlayer(player->GetGUID());
+            return (sIndividualProgression->hasPassedProgression(target, PROGRESSION_WOTLK_TIER_2) && sIndividualProgression->isBeforeProgression(target, PROGRESSION_WOTLK_TIER_3));
+        }
+
+        uint32 GetDailyImageEntry(uint32 QuestId)
+        {
+            switch (QuestId)
+            {
+            case QUEST_SARTHARION_MUST_DIE:
+                return NPC_SARTHARION_IMAGE;
+            case QUEST_ANUBREKHAN_MUST_DIE:
+                return NPC_ANUBREKHAN_IMAGE;
+            case QUEST_NOTH_THE_PLAGUEBINGER_MUST_DIE:
+                return NPC_NOTH_THE_PLAGUEBINGER_IMAGE;
+            case QUEST_INSTRUCTOR_RAZUVIOUS_MUST_DIE:
+                return NPC_INSTRUCTOR_RAZUVIOUS_IMAGE;
+            case QUEST_PATCHWERK_MUST_DIE:
+                return NPC_PATCHWERK_IMAGE;
+            case QUEST_MALYGOS_MUST_DIE:
+                return NPC_MALYGOS_IMAGE;
+            case QUEST_FLAME_LEVIATHAN_MUST_DIE:
+                return NPC_FLAME_LEVIATHAN_IMAGE;
+            case QUEST_RAZORSCALE_MUST_DIE:
+                return NPC_RAZORSCALE_IMAGE;
+            case QUEST_IGNIS_THE_FURNACE_MASTER_MUST_DIE:
+                return NPC_IGNIS_THE_FURNACE_MASTER_IMAGE;
+            case QUEST_XT_002_DECONSTRUCTOR_MUST_DIE:
+                return NPC_XT_002_DECONSTRUCTOR_IMAGE;
+            case QUEST_LORD_JARAXXUS_MUST_DIE:
+                return NPC_LORD_JARAXXUS_IMAGE;
+            case QUEST_LORD_MARROWGAR_MUST_DIE:
+                return NPC_LORD_MARROWGAR_IMAGE;
+            default: // QUEST_PROOF_OF_DEMISE_THE_BLACK_KNIGHT:
+                return NPC_THE_BLACK_KNIGHT_IMAGE;
+            }
+        }
+
+        void JustSummoned(Creature* image) override
+        {
+            if (image->GetEntry() != NPC_ANUBREKHAN_IMAGE)
+                image->SetUnitMovementFlags(MOVEMENTFLAG_RIGHT);
+            _summonGUID = image->GetGUID();
+        }
+
+
+        void UpdateAI(uint32 diff) override
+        {
+            ScriptedAI::UpdateAI(diff);
+
+            _switchImageTimer += diff;
+            if (_switchImageTimer > MINUTE * IN_MILLISECONDS)
+            {
+                _switchImageTimer = 0;
+                QuestRelationBounds objectQR = sObjectMgr->GetCreatureQuestRelationBounds(me->GetEntry());
+
+                for (QuestRelations::const_iterator i = objectQR.first; i != objectQR.second; ++i)
+                {
+                    uint32 questId = i->second;
+                    Quest const* quest = sObjectMgr->GetQuestTemplate(questId);
+
+                    if (!quest || !quest->IsDaily())
+                        continue;
+
+                    uint32 newEntry = GetDailyImageEntry(questId);
+                    if (_summonGUID.GetEntry() != newEntry)
+                    {
+                        if (Creature* image = ObjectAccessor::GetCreature(*me, _summonGUID))
+                            image->DespawnOrUnsummon();
+
+                        float z = 653.622f;
+                        if (newEntry == NPC_KERISTRASZA_IMAGE || newEntry == NPC_CYANIGOSA_IMAGE)
+                            z += 3.0f;
+                        me->SummonCreature(newEntry, 5703.077f, 583.9757f, z, 3.926991f);
+                    }
+                }
+            }
+        }
+    private:
+        uint32 _switchImageTimer;
+        ObjectGuid _summonGUID;
+    };
+};
+
+class npc_archmage_landalock_ipp_3_4 : public CreatureScript
+{
+public:
+    npc_archmage_landalock_ipp_3_4() : CreatureScript("npc_archmage_landalock_3_4") {}
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new npc_archmage_landalockAI(creature);
+    }
+
+    struct npc_archmage_landalockAI : public ScriptedAI
+    {
+        npc_archmage_landalockAI(Creature* creature) : ScriptedAI(creature)
         {
             _switchImageTimer = MINUTE * IN_MILLISECONDS;
             _summonGUID.Clear();
@@ -194,46 +307,44 @@ public:
             return sIndividualProgression->hasPassedProgression(target, PROGRESSION_WOTLK_TIER_3);
         }
 
-        uint32 GetImageEntry(uint32 QuestId)
+        uint32 GetWeeklyImageEntry(uint32 QuestId)
         {
             switch (QuestId)
             {
-                case QUEST_SARTHARION_MUST_DIE:
-                    return NPC_SARTHARION_IMAGE;
-                case QUEST_ANUBREKHAN_MUST_DIE:
-                    return NPC_ANUBREKHAN_IMAGE;
-                case QUEST_NOTH_THE_PLAGUEBINGER_MUST_DIE:
-                    return NPC_NOTH_THE_PLAGUEBINGER_IMAGE;
-                case QUEST_INSTRUCTOR_RAZUVIOUS_MUST_DIE:
-                    return NPC_INSTRUCTOR_RAZUVIOUS_IMAGE;
-                case QUEST_PATCHWERK_MUST_DIE:
-                    return NPC_PATCHWERK_IMAGE;
-                case QUEST_MALYGOS_MUST_DIE:
-                    return NPC_MALYGOS_IMAGE;
-                case QUEST_FLAME_LEVIATHAN_MUST_DIE:
-                    return NPC_FLAME_LEVIATHAN_IMAGE;
-                case QUEST_RAZORSCALE_MUST_DIE:
-                    return NPC_RAZORSCALE_IMAGE;
-                case QUEST_IGNIS_THE_FURNACE_MASTER_MUST_DIE:
-                    return NPC_IGNIS_THE_FURNACE_MASTER_IMAGE;
-                case QUEST_XT_002_DECONSTRUCTOR_MUST_DIE:
-                    return NPC_XT_002_DECONSTRUCTOR_IMAGE;
-                case QUEST_LORD_JARAXXUS_MUST_DIE:
-                    return NPC_LORD_JARAXXUS_IMAGE;
-                case QUEST_LORD_MARROWGAR_MUST_DIE:
-                    return NPC_LORD_MARROWGAR_IMAGE;
-                default: // QUEST_PROOF_OF_DEMISE_THE_BLACK_KNIGHT:
-                    return NPC_THE_BLACK_KNIGHT_IMAGE;
+            case QUEST_SARTHARION_MUST_DIE:
+                return NPC_SARTHARION_IMAGE;
+            case QUEST_ANUBREKHAN_MUST_DIE:
+                return NPC_ANUBREKHAN_IMAGE;
+            case QUEST_NOTH_THE_PLAGUEBINGER_MUST_DIE:
+                return NPC_NOTH_THE_PLAGUEBINGER_IMAGE;
+            case QUEST_INSTRUCTOR_RAZUVIOUS_MUST_DIE:
+                return NPC_INSTRUCTOR_RAZUVIOUS_IMAGE;
+            case QUEST_PATCHWERK_MUST_DIE:
+                return NPC_PATCHWERK_IMAGE;
+            case QUEST_MALYGOS_MUST_DIE:
+                return NPC_MALYGOS_IMAGE;
+            case QUEST_FLAME_LEVIATHAN_MUST_DIE:
+                return NPC_FLAME_LEVIATHAN_IMAGE;
+            case QUEST_RAZORSCALE_MUST_DIE:
+                return NPC_RAZORSCALE_IMAGE;
+            case QUEST_IGNIS_THE_FURNACE_MASTER_MUST_DIE:
+                return NPC_IGNIS_THE_FURNACE_MASTER_IMAGE;
+            case QUEST_XT_002_DECONSTRUCTOR_MUST_DIE:
+                return NPC_XT_002_DECONSTRUCTOR_IMAGE;
+            case QUEST_LORD_JARAXXUS_MUST_DIE:
+                return NPC_LORD_JARAXXUS_IMAGE;
+            default: // case QUEST_LORD_MARROWGAR_MUST_DIE:
+                return NPC_LORD_MARROWGAR_IMAGE;
             }
         }
 
         void JustSummoned(Creature* image) override
         {
-            // xinef: screams like a baby
             if (image->GetEntry() != NPC_ANUBREKHAN_IMAGE)
                 image->SetUnitMovementFlags(MOVEMENTFLAG_RIGHT);
             _summonGUID = image->GetGUID();
         }
+
 
         void UpdateAI(uint32 diff) override
         {
@@ -244,14 +355,16 @@ public:
             {
                 _switchImageTimer = 0;
                 QuestRelationBounds objectQR = sObjectMgr->GetCreatureQuestRelationBounds(me->GetEntry());
+
                 for (QuestRelations::const_iterator i = objectQR.first; i != objectQR.second; ++i)
                 {
                     uint32 questId = i->second;
                     Quest const* quest = sObjectMgr->GetQuestTemplate(questId);
+
                     if (!quest || !quest->IsWeekly())
                         continue;
 
-                    uint32 newEntry = GetImageEntry(questId);
+                    uint32 newEntry = GetWeeklyImageEntry(questId);
                     if (_summonGUID.GetEntry() != newEntry)
                     {
                         if (Creature* image = ObjectAccessor::GetCreature(*me, _summonGUID))
@@ -269,11 +382,11 @@ public:
         uint32 _switchImageTimer;
         ObjectGuid _summonGUID;
     };
-
 };
 
 void AddSC_npc_archmage_timear()
 {
     new npc_archmage_timear();
-    new npc_archmage_landalock_ipp();
+    new npc_archmage_landalock_ipp_3_3();
+    new npc_archmage_landalock_ipp_3_4();
 }


### PR DESCRIPTION
related to: https://github.com/ZhengPeiRu21/mod-individual-progression/issues/1286

Archmage Timear now gives daily quests until WotLK patch 3.2 (progression tier 15)

at progression 15 Archmage Lan'dalock now gives the daily quest, only until patch 3.3 (progression tier 16)

at progression 16 Archmage Lan'dalock no longer gives daily quests. they are now replaced with weekly quests.
