### PR TITLE
AV - fix clickable items 

### DIFF
--- a/src/vanillaScripts/av_quests.cpp
+++ b/src/vanillaScripts/av_quests.cpp
@@ -295,36 +295,29 @@ public:
         if (!player || !item)
             return false;
 
-        Battleground* bg = player->GetBattleground();
-        if (!bg || bg->GetBgTypeID(true) != BATTLEGROUND_AV)
-            return false;
-
-        Unit* selected = player->GetSelectedUnit();
-        if (!selected)
-            return false;
-
-        Creature* creature = selected->ToCreature();
-        if (!creature)
-            return false;
-
-        if (item->GetEntry() == ITEM_FROSTWOLF_MUZZLE && creature->GetEntry() == NPC_AV_FROSTWOLF)
+        if (item->GetEntry() == ITEM_FROSTWOLF_MUZZLE || item->GetEntry() == ITEM_STORMPIKE_COLLAR)
         {
-            if (player->HasQuest(AV_Q_H_STABLES) && player->GetQuestStatus(AV_Q_H_STABLES) == QUEST_STATUS_INCOMPLETE)
+            Unit* selected = player->GetSelectedUnit();
+            if (!selected)
+                return false;
+
+            Creature* creature = selected->ToCreature();
+            if (!creature)
+                return false;
+
+            if (creature->GetEntry() == NPC_AV_FROSTWOLF)
             {
-                player->CompleteQuest(AV_Q_H_STABLES);
-                return true;
+                if (player->HasQuest(AV_Q_H_STABLES) && player->GetQuestStatus(AV_Q_H_STABLES) == QUEST_STATUS_INCOMPLETE)
+                    player->CompleteQuest(AV_Q_H_STABLES);
+            }
+            else if (creature->GetEntry() == NPC_AV_ALTERAC_RAM)
+            {
+                if (player->HasQuest(AV_Q_A_STABLES) && player->GetQuestStatus(AV_Q_A_STABLES) == QUEST_STATUS_INCOMPLETE)
+                    player->CompleteQuest(AV_Q_A_STABLES);
             }
         }
-        else if (item->GetEntry() == ITEM_STORMPIKE_COLLAR && creature->GetEntry() == NPC_AV_ALTERAC_RAM)
-        {
-            if (player->HasQuest(AV_Q_A_STABLES) && player->GetQuestStatus(AV_Q_A_STABLES) == QUEST_STATUS_INCOMPLETE)
-            {
-                player->CompleteQuest(AV_Q_A_STABLES);
-                return true;
-            }
-        }
-
-        return false;
+        
+        return true;
     }
 
     void OnPlayerCompleteQuest(Player* player, Quest const* quest) override


### PR DESCRIPTION
this is connected to the Empty Stables quests

you get an item to use on a wolf or ram.
it needs to complete the quest when you do so.

I use an override function called OnPlayerCanCastItemUseSpell to do this.
it should now properly allow all other items to be cast, it only effects the quest items now.