### PR TITLE
fix Karazhan Midnight

### DIFF
--- a/data/sql/world/base/dungeon_karazhan.sql
+++ b/data/sql/world/base/dungeon_karazhan.sql
@@ -17,6 +17,9 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 22) AND (`SourceGroup` IN (6, 7)) AND (`SourceEntry` = 15551) AND (`ConditionTypeOrReference` = 29);
 
+UPDATE `creature_template` SET `ScriptName` = 'boss_midnight_ipp' WHERE `entry` = 16151;
+UPDATE `creature_template` SET `ScriptName` = 'boss_midnight' WHERE `entry` = 605; -- assigning old script to unused entry to avoid worldserver error about script not being assigned in database
+
 -- Restore Enchanting formula drops to their pre-3.1 rates
 UPDATE `creature_loot_template` SET `Chance` = 5 WHERE `Item` IN (22559, 22561, 22545, 22560);
 

--- a/data/sql/world/base/dungeon_karazhan.sql
+++ b/data/sql/world/base/dungeon_karazhan.sql
@@ -17,9 +17,6 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 22) AND (`SourceGroup` IN (6, 7)) AND (`SourceEntry` = 15551) AND (`ConditionTypeOrReference` = 29);
 
-UPDATE `creature_template` SET `ScriptName` = 'boss_midnight_ipp' WHERE `entry` = 16151;
-UPDATE `creature_template` SET `ScriptName` = 'boss_midnight' WHERE `entry` = 605; -- assigning old script to unused entry to avoid worldserver error about script not being assigned in database
-
 -- Restore Enchanting formula drops to their pre-3.1 rates
 UPDATE `creature_loot_template` SET `Chance` = 5 WHERE `Item` IN (22559, 22561, 22545, 22560);
 
@@ -27,3 +24,14 @@ UPDATE `creature_loot_template` SET `Chance` = 5 WHERE `Item` IN (22559, 22561, 
 UPDATE `item_template` SET `Quality` = 1, `SellPrice` = 0, `description` = 'Used to summon Nightbane in Karazhan' WHERE (`entry` = 24140);
 UPDATE `quest_template` SET `StartItem` = 24140 WHERE `ID` = 9644;
 UPDATE `quest_template_addon` SET `ProvidedItemCount` = 1 WHERE (`ID` = 9644);
+
+-- fix boss reset with Midnight not respawning correctly
+UPDATE `creature_template` SET `ScriptName` = 'boss_midnight_ipp' WHERE `entry` = 16151;
+UPDATE `creature_template` SET `ScriptName` = 'boss_midnight' WHERE `entry` = 605; -- assigning old script to unused entry to avoid worldserver error about script not being assigned in database
+
+-- fix worldserver error when Midnight kills a player, Midnight needs the text as well for Attumen to say the line
+DELETE FROM `creature_text` WHERE `CreatureID` = 16151;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES 
+(16151, 0, 0, '%s calls for her master!', 16, 0, 100, 0, 0, 0, 13439, 0, 'midnight EMOTE_CALL_ATTUMEN'),
+(16151, 1, 0, '%s rushes to her master\'s aid.', 16, 0, 100, 0, 0, 0, 13455, 0, 'midnight EMOTE_MOUNT_UP'),
+(16151, 3, 0, 'Well done, Midnight!', 14, 0, 100, 0, 0, 9173, 15334, 0, 'attumen SAY_MIDNIGHT_KILL');

--- a/src/tbcScripts/instance_karazhan.cpp
+++ b/src/tbcScripts/instance_karazhan.cpp
@@ -4,12 +4,57 @@
 
 #include "Player.h"
 #include "ScriptMgr.h"
+// #include "CreatureScript.h"
+#include "ScriptedCreature.h"
+#include "karazhan.h"
 
 enum BlackUrn
 {
     DATA_NIGHTBANE     = 11,
     NPC_NIGHTBANE      = 17225,
     ITEM_BLACKENED_URN = 24140
+};
+
+enum Texts
+{
+    SAY_KILL = 0,
+    SAY_RANDOM = 1,
+    SAY_DISARMED = 2,
+    SAY_MIDNIGHT_KILL = 3,
+    SAY_APPEAR = 4,
+    SAY_MOUNT = 5,
+
+    SAY_DEATH = 3,
+
+    // Midnight
+    EMOTE_CALL_ATTUMEN = 0,
+    EMOTE_MOUNT_UP = 1
+};
+
+enum Spells
+{
+    // Attumen
+    SPELL_SHADOWCLEAVE = 29832,
+    SPELL_INTANGIBLE_PRESENCE = 29833,
+    SPELL_SPAWN_SMOKE = 10389,
+    SPELL_CHARGE = 29847,
+    // Midnight
+    SPELL_KNOCKDOWN = 29711,
+    SPELL_SUMMON_ATTUMEN = 29714,
+    SPELL_MOUNT = 29770,
+    SPELL_SUMMON_ATTUMEN_MOUNTED = 29799
+};
+
+enum Phases
+{
+    PHASE_NONE,
+    PHASE_ATTUMEN_ENGAGES,
+    PHASE_MOUNTED
+};
+
+enum Actions
+{
+    ACTION_SET_MIDNIGHT_PHASE
 };
 
 class go_blackened_urn_70 : public GameObjectScript
@@ -39,7 +84,121 @@ public:
     }
 };
 
+struct boss_midnight_ipp : public BossAI
+{
+    boss_midnight_ipp(Creature* creature) : BossAI(creature, DATA_ATTUMEN), _phase(PHASE_NONE) { }
+
+    void Reset() override
+    {
+        BossAI::Reset();
+        me->SetVisible(true);
+        me->SetReactState(REACT_DEFENSIVE);
+    }
+
+    bool CanMeleeHit()
+    {
+        return me->GetVictim() && (me->GetVictim()->GetPositionZ() < 53.0f || me->GetVictim()->GetDistance(me->GetHomePosition()) < 50.0f);
+    }
+
+    void DamageTaken(Unit* /*attacker*/, uint32& damage, DamageEffectType /*damageType*/, SpellSchoolMask /*damageSchoolMask*/) override
+    {
+        // Midnight never dies, let health fall to 1 and prevent further damage.
+        if (damage >= me->GetHealth())
+        {
+            damage = me->GetHealth() - 1;
+        }
+
+        if (_phase == PHASE_NONE && me->HealthBelowPctDamaged(95, damage))
+        {
+            _phase = PHASE_ATTUMEN_ENGAGES;
+            Talk(EMOTE_CALL_ATTUMEN);
+            DoCastAOE(SPELL_SUMMON_ATTUMEN);
+        }
+        else if (_phase == PHASE_ATTUMEN_ENGAGES && me->HealthBelowPctDamaged(25, damage))
+        {
+            _phase = PHASE_MOUNTED;
+            DoCastAOE(SPELL_MOUNT, true);
+        }
+    }
+
+    void JustSummoned(Creature* summon) override
+    {
+        if (summon->GetEntry() == NPC_ATTUMEN_THE_HUNTSMAN)
+        {
+            summon->AI()->AttackStart(me->GetVictim());
+            summon->AI()->Talk(SAY_APPEAR);
+        }
+        BossAI::JustSummoned(summon);
+    }
+
+    void DoAction(int32 actionId) override
+    {
+        if (actionId == ACTION_SET_MIDNIGHT_PHASE)
+        {
+            _phase = PHASE_MOUNTED;
+        }
+    }
+
+        void JustEngagedWith(Unit* who) override
+    {
+        BossAI::JustEngagedWith(who);
+        scheduler.Schedule(15s, 25s, [this](TaskContext task)
+        {
+            DoCastVictim(SPELL_KNOCKDOWN);
+            task.Repeat(15s, 25s);
+        });
+    }
+
+    void EnterEvadeMode(EvadeReason /*why*/) override
+    {
+        me->SetVisible(false);
+        me->SetReactState(REACT_DEFENSIVE);
+
+        // Stop combat and movement to ensure a clean teleport
+        me->AttackStop();
+        me->RemoveAllAttackers();
+        me->GetMotionMaster()->MoveIdle();
+
+        Position home = me->GetHomePosition();
+        me->NearTeleportTo(home.GetPositionX(), home.GetPositionY(), home.GetPositionZ(), home.GetOrientation());
+        me->SendTeleportPacket(home);
+
+        _phase = PHASE_NONE;
+    }
+
+    void KilledUnit(Unit* /*victim*/) override
+    {
+        if (_phase == PHASE_ATTUMEN_ENGAGES)
+        {
+            if (Creature* attumen = instance->GetCreature(DATA_ATTUMEN))
+            {
+                Talk(SAY_MIDNIGHT_KILL, attumen);
+            }
+        }
+    }
+
+    void UpdateAI(uint32 diff) override
+    {
+        if (_phase != PHASE_MOUNTED)
+        {
+            if (!UpdateVictim())
+            {
+                return;
+            }
+            if (!CanMeleeHit())
+            {
+                BossAI::EnterEvadeMode(EvadeReason::EVADE_REASON_BOUNDARY);
+            }
+        }
+        scheduler.Update(diff, std::bind(&BossAI::DoMeleeAttackIfReady, this));
+    }
+
+private:
+    uint8 _phase;
+};
+
 void AddSC_karazhan_70()
 {
+    RegisterKarazhanCreatureAI(boss_midnight_ipp);
     new go_blackened_urn_70();
 }

--- a/src/tbcScripts/instance_karazhan.cpp
+++ b/src/tbcScripts/instance_karazhan.cpp
@@ -10,8 +10,6 @@
 
 enum BlackUrn
 {
-    DATA_NIGHTBANE     = 11,
-    NPC_NIGHTBANE      = 17225,
     ITEM_BLACKENED_URN = 24140
 };
 

--- a/src/tbcScripts/karazhan.h
+++ b/src/tbcScripts/karazhan.h
@@ -1,0 +1,225 @@
+/*
+ * This file is part of the AzerothCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef DEF_KARAZHAN_H
+#define DEF_KARAZHAN_H
+
+#include "CreatureAIImpl.h"
+
+#define KarazhanScriptName "instance_karazhan"
+#define DataHeader "KZ"
+
+uint32 const EncounterCount = 12;
+
+enum KZDataTypes
+{
+    DATA_ATTUMEN                    = 0,
+    DATA_MOROES                     = 1,
+    DATA_MAIDEN                     = 2,
+    DATA_OPTIONAL_BOSS              = 3,
+    DATA_OPERA_PERFORMANCE          = 4,
+    DATA_CURATOR                    = 5,
+    DATA_ARAN                       = 6,
+    DATA_TERESTIAN                  = 7,
+    DATA_NETHERSPITE                = 8,
+    DATA_CHESS_EVENT                = 9,
+    DATA_MALCHEZAAR                 = 10,
+    DATA_NIGHTBANE                  = 11,
+    DATA_SERVANT_QUARTERS           = 12,
+    DATA_OPERA_OZ_DEATHCOUNT        = 13,
+    DATA_KILREK                     = 14,
+
+    MAX_ENCOUNTERS                  = 15,
+
+    DATA_GO_CURTAINS                = 18,
+    DATA_GO_STAGEDOORLEFT           = 19,
+    DATA_GO_STAGEDOORRIGHT          = 20,
+    DATA_GO_LIBRARY_DOOR            = 21,
+    DATA_GO_MASSIVE_DOOR            = 22,
+    DATA_GO_GAME_DOOR               = 24,
+    DATA_GO_GAME_EXIT_DOOR          = 25,
+    DATA_IMAGE_OF_MEDIVH            = 26,
+    DATA_GO_SIDE_ENTRANCE_DOOR      = 29,
+    DATA_PRINCE                     = 30,
+    DATA_SPAWN_OPERA_DECORATIONS    = 31,
+    DATA_MIDNIGHT                   = 32,
+
+    // Chess Event
+    CHESS_EVENT_TEAM                = 33,
+    DATA_CHESS_REINIT_PIECES        = 34,
+    DATA_CHESS_GAME_PHASE           = 35,
+    DATA_ECHO_OF_MEDIVH             = 36,
+    DATA_DUST_COVERED_CHEST         = 37,
+
+    // Specific Opera Data
+    DATA_DOROTHEE                   = 38,
+    DATA_ROMULO                     = 39,
+    DATA_JULIANNE                   = 40,
+
+    DATA_ROAR                       = 41,
+    DATA_STRAWMAN                   = 42,
+    DATA_TINHEAD                    = 43,
+    DATA_TITO                       = 44,
+
+    DATA_MIRKBLOOD                  = 45
+};
+
+enum KZOperaEvents
+{
+    EVENT_OZ    = 1,
+    EVENT_HOOD  = 2,
+    EVENT_RAJ   = 3
+};
+
+enum KZCreatures
+{
+    NPC_HYAKISS_THE_LURKER              = 16179,
+    NPC_ROKAD_THE_RAVAGER               = 16181,
+    NPC_SHADIKITH_THE_GLIDER            = 16180,
+    NPC_TERESTIAN_ILLHOOF               = 15688,
+    NPC_MOROES                          = 15687,
+    NPC_ATTUMEN_THE_HUNTSMAN            = 15550,
+    NPC_ATTUMEN_THE_HUNTSMAN_MOUNTED    = 16152,
+    NPC_MIDNIGHT                        = 16151,
+    NPC_NIGHTBANE                       = 17225,
+    NPC_SHADE_OF_ARAN                   = 16524,
+
+    // Trash
+    NPC_COLDMIST_WIDOW                  = 16171,
+    NPC_COLDMIST_STALKER                = 16170,
+    NPC_SHADOWBAT                       = 16173,
+    NPC_VAMPIRIC_SHADOWBAT              = 16175,
+    NPC_GREATER_SHADOWBAT               = 16174,
+    NPC_PHASE_HOUND                     = 16178,
+    NPC_DREADBEAST                      = 16177,
+    NPC_SHADOWBEAST                     = 16176,
+    NPC_KILREK                          = 17229,
+    NPC_RELAY                           = 17645,
+    NPC_BARNES                          = 16812,
+    NPC_DOROTHEE                        = 17535,
+    NPC_TITO                            = 17548,
+    NPC_ROMULO                          = 17533,
+    NPC_JULIANNE                        = 17534,
+    NPC_ROAR                            = 17546,
+    NPC_STRAWMAN                        = 17543,
+    NPC_TINHEAD                         = 17547,
+    NPC_FIENDISH_IMP                    = 17267,
+
+    // Chess Event
+    NPC_ECHO_OF_MEDIVH                  = 16816,
+    NPC_PAWN_H                          = 17469,
+    NPC_PAWN_A                          = 17211,
+    NPC_KNIGHT_H                        = 21748,
+    NPC_KNIGHT_A                        = 21664,
+    NPC_QUEEN_H                         = 21750,
+    NPC_QUEEN_A                         = 21683,
+    NPC_BISHOP_H                        = 21747,
+    NPC_BISHOP_A                        = 21682,
+    NPC_ROOK_H                          = 21726,
+    NPC_ROOK_A                          = 21160,
+    NPC_KING_H                          = 21752,
+    NPC_KING_A                          = 21684,
+    NPC_CHESS_EVENT_MEDIVH_CHEAT_FIRES  = 22521,
+
+    // Malchezaar Helpers
+    NPC_INFERNAL_TARGET                 = 17644,
+    NPC_INFERNAL_RELAY                  = 17645,
+
+    NPC_TENRIS_MIRKBLOOD                = 28194
+
+};
+
+enum KZGameObjectIds
+{
+    GO_STAGE_CURTAIN                = 183932,
+    GO_STAGE_DOOR_LEFT              = 184278,
+    GO_STAGE_DOOR_RIGHT             = 184279,
+    GO_PRIVATE_LIBRARY_DOOR         = 184517,
+    GO_MASSIVE_DOOR                 = 185521,
+    GO_GAMESMAN_HALL_DOOR           = 184276,
+    GO_GAMESMAN_HALL_EXIT_DOOR      = 184277,
+    GO_NETHERSPACE_DOOR             = 185134,
+    GO_MASTERS_TERRACE_DOOR         = 184274,
+    GO_MASTERS_TERRACE_DOOR2        = 184280,
+    GO_SIDE_ENTRANCE_DOOR           = 184275,
+    GO_DUST_COVERED_CHEST           = 185119,
+
+     // Opera event stage decoration
+    GO_OZ_BACKDROP                  = 183442,
+    GO_OZ_HAY                       = 183496,
+    GO_HOOD_BACKDROP                = 183491,
+    GO_HOOD_TREE                    = 183492,
+    GO_HOOD_HOUSE                   = 183493,
+    GO_RAJ_BACKDROP                 = 183443,
+    GO_RAJ_MOON                     = 183494,
+    GO_RAJ_BALCONY                  = 183495
+};
+
+enum KZMisc
+{
+    OPTIONAL_BOSS_REQUIRED_DEATH_COUNT      = 50,
+
+    ACTION_CHESS_PIECE_RESET_ORIENTATION    = 1
+};
+
+enum KarazhanSpells
+{
+    SPELL_RATTLED           = 32437,
+    SPELL_OVERLOAD          = 29766,
+    SPELL_BLINK             = 29884,
+
+    // Chess Event
+    SPELL_GAME_IN_SESSION   = 39331,
+    SPELL_HAND_OF_MEDIVH    = 39339, // 1st cheat: AOE spell burn cell under enemy chesspieces.
+    SPELL_FURY_OF_MEDIVH    = 39383  // 2nd cheat: Berserk own chesspieces.
+};
+
+enum KarazhanChessGamePhase
+{
+    CHESS_PHASE_NOT_STARTED     = 0,
+    CHESS_PHASE_PVE_WARMUP      = 1, // Medivh has been spoken too but king isn't controlled yet
+    CHESS_PHASE_INPROGRESS_PVE  = 2,
+    CHESS_PHASE_FAILED          = 3,
+    CHESS_PHASE_PVE_FINISHED    = 4,
+    CHESS_PHASE_PVP_WARMUP      = 5,
+    CHESS_PHASE_INPROGRESS_PVP  = 6  // Get back to PVE_FINISHED after that
+};
+
+enum KarazhanChessGameFactions
+{
+    CHESS_FACTION_HORDE         = 1689,
+    CHESS_FACTION_ALLIANCE      = 1690,
+    CHESS_FACTION_BOTH          = 536
+};
+
+enum InstanceActions
+{
+    ACTION_SCHEDULE_RAJ_CHECK,
+
+    ACTION_DO_RESURRECT = 4,
+    ACTION_RESS_ROMULO  = 5,
+};
+
+template <class AI, class T>
+inline AI* GetKarazhanAI(T* obj)
+{
+    return GetInstanceAI<AI>(obj, KarazhanScriptName);
+}
+
+#define RegisterKarazhanCreatureAI(ai_name) RegisterCreatureAIWithFactory(ai_name, GetKarazhanAI)
+
+#endif


### PR DESCRIPTION
- when the boss fight resets Midnight bugged out.
Midnight failed to respawn properly.
Instead of respawning him, I'm teleporting him back to his spawn and resetting his combat flags.

- On kill he says `SAY_MIDNIGHT_KILL`, which is text group 3.
but he has no text for group 3, so this produced an error in the worldserver console.
both the creature initiating the text and the creature saying the text need to have the text group.
