### PR TITLE
fix compile error on Linux

### DIFF
--- a/src/tbcScripts/instance_karazhan.cpp
+++ b/src/tbcScripts/instance_karazhan.cpp
@@ -302,7 +302,7 @@ public:
 
     CreatureAI* GetAI(Creature* creature) const override
     {
-        return new typename boss_attumen(creature);
+        return new boss_attumen(creature);
     }
 };
 
@@ -428,7 +428,7 @@ public:
 
     CreatureAI* GetAI(Creature* creature) const override
     {
-        return new typename boss_midnight(creature);
+        return new boss_midnight(creature);
     }
 };
 


### PR DESCRIPTION
"Linux compilers reject typename used before a non-dependent, non-template-qualified name. 
MSVC is permissive, which is why it compiled on Windows."