### PR TITLE
allow setting progression back to 0

### DIFF
--- a/src/IndividualProgression.cpp
+++ b/src/IndividualProgression.cpp
@@ -78,7 +78,7 @@ void IndividualProgression::ForceUpdateProgressionState(Player* player, Progress
     if (!player || !player->IsInWorld())
         return;
 
-    if (!newState)
+    if (!newState && newState != 0)
         return;
 
     // remove all hidden progression quests first


### PR DESCRIPTION
the issue is that 0 in cpp is seen as `false` (0 = false, 1 = true)

there was a check for `no progression level given` in the `set` command, it would then cancel the request and do nothing.
0 counted as no progression level given.