### PR TITLE
BRD - fix Magmus damage

### DIFF
--- a/src/vanillaScripts/instance_blackrock_depths.cpp
+++ b/src/vanillaScripts/instance_blackrock_depths.cpp
@@ -48,8 +48,8 @@ enum DarkKeepers
 
 enum Spells
 {
-    SPELL_FIERYBURST = 13900,
-    SPELL_WARSTOMP = 24375
+    SPELL_FIERYBURST = 15668,
+    SPELL_WARSTOMP = 15593
 };
 
 enum DataTypes


### PR DESCRIPTION
he was using the wrong versions of Fiery Burst and War Stomp

https://www.wowhead.com/classic/npc=9938/magmus