### PR TITLE
Solve Chaos and Destruction

### DIFF
--- a/data/sql/world/base/aq_gate_quest.sql
+++ b/data/sql/world/base/aq_gate_quest.sql
@@ -50,7 +50,6 @@ UPDATE `quest_template` SET `QuestDescription` = 'First things first! We need to
 UPDATE `quest_template_locale` SET `Details` = 'Commençons par le commencement ! Il faut comprendre ce que Azuregos a écrit dans ce registre. Vous dites qu''il vous a demandé de fabriquer une bouée en arcanite avec le schéma ? Étrange qu''il ait écrit ça en draconique. Ce vieux bouc sait que je ne peux pas déchiffrer ces absurdités. Pour que ça marche, il me faut mes lunettes de divination, un poulet de deux cents kilos et le tome II de Draconique pour les Nuls.', `Objectives` = 'Nous devons découvrir ce que Azuregos a écrit dans ce registre.',  `CompletedText` = 'Nous devons découvrir ce que Azuregos a écrit dans ce registre.' WHERE `ID` = 8576 AND `locale` = 'frFR';
 
 -- New 'Bang a Gong!' quest. No rewards for completing this version. No mount, no title. Currently the Mallet of Zul'Farrak is required to bang the gong.
--- New 'Chaos and Destruction' quest. Kill Colossus of Zora(15740), Regal(15741) and Ashi(15742)
 DELETE FROM `quest_template` WHERE `ID` IN (108743, 108744, 108745, 108746, 108747);
 INSERT INTO `quest_template` (`ID`, `QuestType`, `QuestLevel`, `MinLevel`, `QuestSortID`, `QuestInfoID`, `SuggestedGroupNum`, `RequiredFactionId1`, `RequiredFactionId2`, `RequiredFactionValue1`, `RequiredFactionValue2`, `RewardNextQuest`, `RewardXPDifficulty`, `RewardMoney`, `RewardMoneyDifficulty`, `RewardDisplaySpell`, `RewardSpell`, `RewardHonor`, `RewardKillHonor`, 
 `StartItem`, `Flags`, `RequiredPlayerKills`, `RewardItem1`, `RewardAmount1`, `RewardItem2`, `RewardAmount2`, `RewardItem3`, `RewardAmount3`, `RewardItem4`, `RewardAmount4`, `ItemDrop1`, `ItemDropQuantity1`, `ItemDrop2`, `ItemDropQuantity2`, `ItemDrop3`, `ItemDropQuantity3`, `ItemDrop4`, `ItemDropQuantity4`, 
@@ -60,7 +59,7 @@ INSERT INTO `quest_template` (`ID`, `QuestType`, `QuestLevel`, `MinLevel`, `Ques
 `RequiredItemCount1`, `RequiredItemCount2`, `RequiredItemCount3`, `RequiredItemCount4`, `RequiredItemCount5`, `RequiredItemCount6`, `Unknown0`, `ObjectiveText1`, `ObjectiveText2`, `ObjectiveText3`, `ObjectiveText4`, `VerifiedBuild`) VALUES 
 
 (108743, 0, 60, 60, 1377, 82, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Simply Bang a Gong!', '', '', NULL, 'Return to The Scarab Gong in Silithus.', 0, 0, 0, 0, 0, 0, 0, 0, 9240, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 3, '', '', '', '', 12340),
-(108744, 2, 60, 60, 1377, 82, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 910, 7, 0, 609, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Chaos and Destruction', 'Kill Lieutenant General Nokhor, 3 Colossal Anubisath Warbringers and 12 Supreme Anubisath Warbringers.', '', '', 'Return to Jonathan the Revelator at the Scarab Gong.', 15818, 15743, 15758, 0, 1, 3, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '', '', '', '', NULL),
+(108744, 2, 60, 60, 1377, 82, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 910, 7, 0, 609, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Chaos and Destruction', 'Kill Lieutenant General Nokhor.', '', '', 'Return to Jonathan the Revelator at the Scarab Gong.', 15818, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '', '', '', '', NULL),
 (108745, 2, 60, 60, 1377, 82, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 910, 7, 0, 609, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Colossus of Zora', 'Kill the Colossus of Zora.', '', '', 'Return to Jonathan the Revelator at the Scarab Gong.', 15740, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '', '', '', '', NULL),
 (108746, 2, 60, 60, 1377, 82, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 910, 7, 0, 609, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Colossus of Regal', 'Kill the Colossus of Regal.', '', '', 'Return to Jonathan the Revelator at the Scarab Gong.', 15741, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '', '', '', '', NULL),
 (108747, 2, 60, 60, 1377, 82, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 910, 7, 0, 609, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Colossus of Ashi', 'Kill the Colossus of Ashi.', '', '', 'Return to Jonathan the Revelator at the Scarab Gong.', 15742, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '', '', '', '', NULL);
@@ -74,8 +73,6 @@ INSERT INTO `quest_template_addon` (`ID`, `MaxLevel`, `AllowableClasses`, `Sourc
 (108745, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 258),
 (108746, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 258),
 (108747, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 258);
-
-UPDATE `quest_template` SET `RewardNextQuest` = 0 WHERE `ID` = 8743; -- can be removed later
 
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 19 AND `ConditionTypeOrReference` = 8 AND `SourceEntry` IN (8286, 8857, 8858, 8859, 108743, 108744, 108745, 108746, 108747);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, 
@@ -104,12 +101,12 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 DELETE FROM `quest_request_items` WHERE `ID` IN (108743, 108744);
 INSERT INTO `quest_request_items` (`ID`, `EmoteOnComplete`, `EmoteOnIncomplete`, `CompletionText`, `VerifiedBuild`) VALUES 
 (108743, 1, 0, 'The Scarab Gong looms ominously before you. Steel yourself, $N; for once the Scarab Gong is rung, the gates of Ahn\'Qiraj will be opened.$B$BHowever, the Brood of Nozdomu and the Cenarion Circle will not reward you, unless you aid them.', 12340),
-(108744, 1, 0, '', NULL);
+(108744, 1, 0, 'To end the war we need to cut the head of the snake. Find and kill Lieutenant General Nokhor. Look for him near the hives.', NULL);
 
 DELETE FROM `quest_offer_reward` WHERE `ID` IN (108743, 108744);
 INSERT INTO `quest_offer_reward` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `RewardText`, `VerifiedBuild`) VALUES 
 (108743, 0, 0, 0, 0, 0, 0, 0, 0, 'From the ground near the gong springs a special crystal. Perhaps favor from the Brood.', 12340),
-(108744, 0, 0, 0, 0, 0, 0, 0, 0, '', NULL);
+(108744, 0, 0, 0, 0, 0, 0, 0, 0, 'Finally, we may rejoice! We owe you a debt we can never repay.', NULL);
     
 DELETE FROM `quest_template_addon` WHERE `ID` IN (8743);
 INSERT INTO `quest_template_addon` (`ID`, `MaxLevel`, `AllowableClasses`, `SourceSpellID`, `PrevQuestID`, `NextQuestID`, `ExclusiveGroup`, `RewardMailTemplateID`, `RewardMailDelay`, 

--- a/data/sql/world/base/aq_gate_quest.sql
+++ b/data/sql/world/base/aq_gate_quest.sql
@@ -101,7 +101,7 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 DELETE FROM `quest_request_items` WHERE `ID` IN (108743, 108744);
 INSERT INTO `quest_request_items` (`ID`, `EmoteOnComplete`, `EmoteOnIncomplete`, `CompletionText`, `VerifiedBuild`) VALUES 
 (108743, 1, 0, 'The Scarab Gong looms ominously before you. Steel yourself, $N; for once the Scarab Gong is rung, the gates of Ahn\'Qiraj will be opened.$B$BHowever, the Brood of Nozdomu and the Cenarion Circle will not reward you, unless you aid them.', 12340),
-(108744, 1, 0, 'To end the war we need to cut the head of the snake. Find and kill Lieutenant General Nokhor. Look for him near the hives.', NULL);
+(108744, 1, 0, 'To end the war we need to cut off the head of the snake. Find and kill Lieutenant General Nokhor. Look for him near the hives.', NULL);
 
 DELETE FROM `quest_offer_reward` WHERE `ID` IN (108743, 108744);
 INSERT INTO `quest_offer_reward` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `RewardText`, `VerifiedBuild`) VALUES 

--- a/src/IndividualProgression.h
+++ b/src/IndividualProgression.h
@@ -44,7 +44,8 @@ enum ProgressionBossIDs
     GILNID               = 1763,
     COLOSSUS_ZORA        = 15740,
     COLOSSUS_REGAL       = 15741,
-    COLOSSUS_ASHI        = 15742
+    COLOSSUS_ASHI        = 15742,
+    GENERAL_NOKHOR       = 15818
 };
 
 enum BuffSpells

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -638,32 +638,52 @@ public:
         if (!sIndividualProgression->enabled || !killed || !killer || !killer->IsInWorld())
             return;
 
+        Group* group = killer->GetGroup();
+        uint32 entry = killed->GetEntry();
+
         if (killer->GetMap()->GetId() == MAP_DEADMINES)
         {
-            switch (killed->GetEntry())
+            if (entry == RHAHK_ZOR || entry == SNEED || entry == GILNID)
             {
-            case RHAHK_ZOR:
-                killer->RemoveAura(IPP_PHASE);
-                killer->RemoveAura(IPP_PHASE_II);
-                killer->RemoveAura(IPP_PHASE_III);
-                killer->CastSpell(killer, IPP_PHASE, false);
-                break;
-            case SNEED:
-                killer->RemoveAura(IPP_PHASE);
-                killer->RemoveAura(IPP_PHASE_II);
-                killer->RemoveAura(IPP_PHASE_III);
-                killer->CastSpell(killer, IPP_PHASE, false);
-                killer->CastSpell(killer, IPP_PHASE_II, false);
-                break;
-            case GILNID:
-                killer->RemoveAura(IPP_PHASE);
-                killer->RemoveAura(IPP_PHASE_II);
-                killer->RemoveAura(IPP_PHASE_III);
-                killer->CastSpell(killer, IPP_PHASE, false);
-                killer->CastSpell(killer, IPP_PHASE_II, false);
-                killer->CastSpell(killer, IPP_PHASE_III, false);
-                break;
+                if (group)
+                {
+                    for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
+                    {
+                        Player* member = itr->GetSource();
+                        if (!member || !sIndividualProgression->isNormalAccount(member))
+                            continue;
+
+                        switch (entry)
+                        {
+                        case RHAHK_ZOR:
+                            member->CastSpell(member, IPP_PHASE, false);
+                            break;
+                        case SNEED:
+                            member->CastSpell(member, IPP_PHASE_II, false);
+                            break;
+                        case GILNID:
+                            member->CastSpell(member, IPP_PHASE_III, false);
+                            break;
+                        }
+                    }
+                }
+                else // no group
+                {
+                    switch (entry)
+                    {
+                    case RHAHK_ZOR:
+                        killer->CastSpell(killer, IPP_PHASE, false);
+                        break;
+                    case SNEED:
+                        killer->CastSpell(killer, IPP_PHASE_II, false);
+                        break;
+                    case GILNID:
+                        killer->CastSpell(killer, IPP_PHASE_III, false);
+                        break;
+                    }
+                }
             }
+            return;
         }
 
         if (killer->GetMap()->GetId() == MAP_ALTERAC_VALLEY)
@@ -702,10 +722,9 @@ public:
                         bg->RewardHonorToTeam(198, teamId);
                 }
             }
+            return;
         }
 
-        Group* group = killer->GetGroup();
-        
         if (killed->GetCreatureTemplate()->rank > CREATURE_ELITE_NORMAL)
         {       
             if (sIndividualProgression->disableDefaultProgression)
@@ -734,18 +753,8 @@ public:
                     return;
             }
    
-            if (killed->GetEntry() == COLOSSUS_ZORA || killed->GetEntry() == COLOSSUS_REGAL || killed->GetEntry() == COLOSSUS_ASHI || killed->GetEntry() == GENERAL_NOKHOR)
+            if (entry == COLOSSUS_ZORA || entry == COLOSSUS_REGAL || entry == COLOSSUS_ASHI || entry == GENERAL_NOKHOR)
             {
-                // no group
-                if (killed->GetEntry() == COLOSSUS_ZORA)
-                    killer->CompleteQuest(QUEST_COLOSSUS_ZORA);
-                else if (killed->GetEntry() == COLOSSUS_REGAL)
-                    killer->CompleteQuest(QUEST_COLOSSUS_REGAL);
-                else if (killed->GetEntry() == COLOSSUS_ASHI)
-                    killer->CompleteQuest(QUEST_COLOSSUS_ASHI);
-                else if (killed->GetEntry() == GENERAL_NOKHOR)
-                    killer->CompleteQuest(CHAOS_AND_DESTRUCTION);
-                
                 if (group)
                 {
                     for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
@@ -754,20 +763,51 @@ public:
                         if (!member || !sIndividualProgression->isNormalAccount(member))
                             continue;
 
-                        if (killed->GetEntry() == COLOSSUS_ZORA)
-                            member->CompleteQuest(QUEST_COLOSSUS_ZORA);
-                        else if (killed->GetEntry() == COLOSSUS_REGAL)
-                            member->CompleteQuest(QUEST_COLOSSUS_REGAL);
-                        else if (killed->GetEntry() == COLOSSUS_ASHI)
-                            member->CompleteQuest(QUEST_COLOSSUS_ASHI);
-                        else if (killed->GetEntry() == GENERAL_NOKHOR)
-                            member->CompleteQuest(CHAOS_AND_DESTRUCTION);
+                        switch (entry)
+                        {
+                        case COLOSSUS_ZORA:
+                            if (member->HasQuest(QUEST_COLOSSUS_ZORA))
+                                member->CompleteQuest(QUEST_COLOSSUS_ZORA);
+                            break;
+                        case COLOSSUS_REGAL:
+                            if (member->HasQuest(QUEST_COLOSSUS_REGAL))
+                                member->CompleteQuest(QUEST_COLOSSUS_REGAL);
+                            break;
+                        case COLOSSUS_ASHI:
+                            if (member->HasQuest(QUEST_COLOSSUS_ASHI))
+                                member->CompleteQuest(QUEST_COLOSSUS_ASHI);
+                            break;
+                        case GENERAL_NOKHOR:
+                            if (member->HasQuest(CHAOS_AND_DESTRUCTION))
+                                member->CompleteQuest(CHAOS_AND_DESTRUCTION);
+                            break;
+                        }
+                    }
+                }
+                else // no group
+                {
+                    switch (entry)
+                    {
+                    case COLOSSUS_ZORA:
+                        if (killer->HasQuest(QUEST_COLOSSUS_ZORA))
+                            killer->CompleteQuest(QUEST_COLOSSUS_ZORA);
+                        break;
+                    case COLOSSUS_REGAL:
+                        if (killer->HasQuest(QUEST_COLOSSUS_REGAL))
+                            killer->CompleteQuest(QUEST_COLOSSUS_REGAL);
+                        break;
+                    case COLOSSUS_ASHI:
+                        if (killer->HasQuest(QUEST_COLOSSUS_ASHI))
+                            killer->CompleteQuest(QUEST_COLOSSUS_ASHI);
+                        break;
+                    case GENERAL_NOKHOR:
+                        if (killer->HasQuest(CHAOS_AND_DESTRUCTION))
+                            killer->CompleteQuest(CHAOS_AND_DESTRUCTION);
+                        break;
                     }
                 }
                 return;
             }
-
-            uint32 ENTRY_KILLED = killed->GetEntry();
 
             if (group)
             {
@@ -779,14 +819,14 @@ public:
 
                     if (killer->IsAtLootRewardDistance(member))
                     {
-                        if (!sIndividualProgression->hasCustomProgressionValue(ENTRY_KILLED))
+                        if (!sIndividualProgression->hasCustomProgressionValue(entry))
                             sIndividualProgression->checkKillProgression(member, killed);
                     }
                 }
             }
             else // no group
             {
-                if (!sIndividualProgression->hasCustomProgressionValue(ENTRY_KILLED))
+                if (!sIndividualProgression->hasCustomProgressionValue(entry))
                     sIndividualProgression->checkKillProgression(killer, killed);
             }
         }

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -734,7 +734,7 @@ public:
                     return;
             }
    
-            if (killed->GetEntry() == COLOSSUS_ZORA || killed->GetEntry() == COLOSSUS_REGAL || killed->GetEntry() == COLOSSUS_ASHI)
+            if (killed->GetEntry() == COLOSSUS_ZORA || killed->GetEntry() == COLOSSUS_REGAL || killed->GetEntry() == COLOSSUS_ASHI || killed->GetEntry() == GENERAL_NOKHOR)
             {
                 // no group
                 if (killed->GetEntry() == COLOSSUS_ZORA)
@@ -742,8 +742,10 @@ public:
                 else if (killed->GetEntry() == COLOSSUS_REGAL)
                     killer->CompleteQuest(QUEST_COLOSSUS_REGAL);
                 else if (killed->GetEntry() == COLOSSUS_ASHI)
-                    killer->CompleteQuest(QUEST_COLOSSUS_ASHI);    
-               
+                    killer->CompleteQuest(QUEST_COLOSSUS_ASHI);
+                else if (killed->GetEntry() == GENERAL_NOKHOR)
+                    killer->CompleteQuest(CHAOS_AND_DESTRUCTION);
+                
                 if (group)
                 {
                     for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
@@ -758,6 +760,8 @@ public:
                             member->CompleteQuest(QUEST_COLOSSUS_REGAL);
                         else if (killed->GetEntry() == COLOSSUS_ASHI)
                             member->CompleteQuest(QUEST_COLOSSUS_ASHI);
+                        else if (killed->GetEntry() == GENERAL_NOKHOR)
+                            member->CompleteQuest(CHAOS_AND_DESTRUCTION);
                     }
                 }
                 return;


### PR DESCRIPTION
For some people the quest `Chaos and Destruction` does not complete normally.
I can't reproduce this issue, but enough people have reported it now that I want to solve it.

This used to be an issue for the quests to kill the Hive bosses as well.
Adding a forced quest completion on creature kill seems to have solved those.

Because `Chaos and Destruction` asked you to kill several creatures, 
I had to change the quest to just needing to kill Lieutenant General Nokhor.
This way I was able to add the same forced quest completion after creature kill.

I've added some quest text as well. On quest pick up and completion.
Just some basic lines that came to mind.
If someone ever comes up with better lines, I'll be happy to change them.