### PR TITLE
fix Rise Obsidion multi spawn

### DIFF
--- a/data/sql/world/base/zone_searing_gorge.sql
+++ b/data/sql/world/base/zone_searing_gorge.sql
@@ -68,6 +68,10 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 /* fix quest: Rise. Obsidion! */
 UPDATE `creature_template` SET `flags_extra` = 0  WHERE `entry` = 8400; -- Obsidion
 
+-- remove spawn on quest accept. This spawned multiple copies while in a party. you have to click the Altar of Suntara to start the event
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 8417;
+UPDATE `creature_template` SET `AIName` = '' WHERE `entry` = 8417;
+
 DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` IN (839101);
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` IN (8391, 8400);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, 

--- a/data/sql/world/base/zone_searing_gorge.sql
+++ b/data/sql/world/base/zone_searing_gorge.sql
@@ -72,33 +72,40 @@ UPDATE `creature_template` SET `flags_extra` = 0  WHERE `entry` = 8400; -- Obsid
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 8417;
 UPDATE `creature_template` SET `AIName` = '' WHERE `entry` = 8417;
 
-DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` IN (839101);
+DELETE FROM `smart_scripts` WHERE `source_type` = 1 AND `entryorguid` = 148498;
+DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` = 839101;
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` IN (8391, 8400);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, 
 `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, 
 `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, 
 `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
 --
-(8391, 0, 0, 0, 25, 0, 100, 257, 0, 0, 0, 0, 0, 0, 80, 839101, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,              'Lathoric the Black - On Reset - Run Script 839101'),
-(8391, 0, 1, 0, 1, 0, 100, 1, 8000, 8000, 0, 0, 0, 0, 1, 0, 5000, 0, 0, 0, 0, 19, 8421, 100, 0, 0, 0, 0, 0, 0,        'Lathoric the Black - OOC - Say (Dorius)'),
-(8391, 0, 2, 0, 52, 0, 100, 0, 0, 8421, 0, 0, 0, 0, 1, 1, 5000, 0, 0, 0, 0, 19, 8421, 100, 0, 0, 0, 0, 0, 0,          'Lathoric the Black - On Text Over - Say (Dorius)'),
-(8391, 0, 3, 0, 52, 0, 100, 0, 1, 8421, 0, 0, 0, 0, 1, 2, 5000, 0, 0, 0, 0, 19, 8421, 100, 0, 0, 0, 0, 0, 0,          'Lathoric the Black - On Text Over - Say (Dorius)'),
-(8391, 0, 4, 0, 52, 0, 100, 0, 2, 8421, 0, 0, 0, 0, 1, 3, 5000, 0, 0, 0, 0, 19, 8421, 100, 0, 0, 0, 0, 0, 0,          'Lathoric the Black - On Text Over - Say (Dorius)'),
-(8391, 0, 5, 0, 52, 0, 100, 0, 3, 8421, 0, 0, 0, 0, 1, 4, 5000, 0, 0, 0, 0, 19, 8421, 100, 0, 0, 0, 0, 0, 0,          'Lathoric the Black - On Text Over - Say (Dorius)'),
-(8391, 0, 6, 0, 52, 0, 100, 0, 4, 8421, 0, 0, 0, 0, 1, 0, 5000, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                'Lathoric the Black - On Text Over - Say'),
-(8391, 0, 7, 0, 52, 0, 100, 0, 0, 8391, 0, 0, 0, 0, 1, 1, 2000, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                'Lathoric the Black - On Text Over - Say'),
-(8391, 0, 8, 9, 52, 0, 100, 512, 1, 8391, 0, 0, 0, 0, 45, 1, 1, 0, 0, 0, 0, 10, 5799, 8400, 0, 0, 0, 0, 0, 0,         'Lathoric the Black - On Text Over - Send Data to Obsidion'),
-(8391, 0, 9, 10, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 19, 768, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                'Lathoric the Black - Linked - Remove Unit Flags'),
-(8391, 0, 10, 11, 61, 0, 100, 513, 0, 0, 0, 0, 0, 0, 8, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Lathoric the Black - Linked - Set React State Aggressive'),
-(8391, 0, 11, 0, 61, 0, 100, 513, 0, 0, 0, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0, 21, 100, 0, 0, 0, 0, 0, 0, 0,               'Lathoric the Black - Linked - Attack Nearest Player'),
-(8391, 0, 12, 0, 7, 0, 100, 513, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                   'Lathoric the Black - On Evade - Despawn'),
+(8391, 0, 0, 0, 25, 0, 100, 257, 0, 0, 0, 0, 0, 0, 80, 839101, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,               'Lathoric the Black - On Reset - Run Script 839101'),
+(8391, 0, 1, 0, 1, 0, 100, 1, 8000, 8000, 0, 0, 0, 0, 1, 0, 5000, 0, 0, 0, 0, 19, 8421, 100, 0, 0, 0, 0, 0, 0,         'Lathoric the Black - OOC - Say (Dorius)'),
+(8391, 0, 2, 0, 52, 0, 100, 0, 0, 8421, 0, 0, 0, 0, 1, 1, 5000, 0, 0, 0, 0, 19, 8421, 100, 0, 0, 0, 0, 0, 0,           'Lathoric the Black - On Text Over - Say (Dorius)'),
+(8391, 0, 3, 0, 52, 0, 100, 0, 1, 8421, 0, 0, 0, 0, 1, 2, 5000, 0, 0, 0, 0, 19, 8421, 100, 0, 0, 0, 0, 0, 0,           'Lathoric the Black - On Text Over - Say (Dorius)'),
+(8391, 0, 4, 0, 52, 0, 100, 0, 2, 8421, 0, 0, 0, 0, 1, 3, 5000, 0, 0, 0, 0, 19, 8421, 100, 0, 0, 0, 0, 0, 0,           'Lathoric the Black - On Text Over - Say (Dorius)'),
+(8391, 0, 5, 0, 52, 0, 100, 0, 3, 8421, 0, 0, 0, 0, 1, 4, 5000, 0, 0, 0, 0, 19, 8421, 100, 0, 0, 0, 0, 0, 0,           'Lathoric the Black - On Text Over - Say (Dorius)'),
+(8391, 0, 6, 0, 52, 0, 100, 0, 4, 8421, 0, 0, 0, 0, 1, 0, 5000, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Lathoric the Black - On Text Over - Say'),
+(8391, 0, 7, 0, 52, 0, 100, 0, 0, 8391, 0, 0, 0, 0, 1, 1, 2000, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Lathoric the Black - On Text Over - Say'),
+(8391, 0, 8, 9, 52, 0, 100, 512, 1, 8391, 0, 0, 0, 0, 45, 1, 1, 0, 0, 0, 0, 10, 5799, 8400, 0, 0, 0, 0, 0, 0,          'Lathoric the Black - On Text Over - Send Data to Obsidion'),
+(8391, 0, 9, 10, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 19, 768, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Lathoric the Black - Linked - Remove Unit Flags'),
+(8391, 0, 10, 11, 61, 0, 100, 513, 0, 0, 0, 0, 0, 0, 8, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                   'Lathoric the Black - Linked - Set React State Aggressive'),
+(8391, 0, 11, 0, 61, 0, 100, 513, 0, 0, 0, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0, 21, 100, 0, 0, 0, 0, 0, 0, 0,                'Lathoric the Black - Linked - Attack Nearest Player'),
+(8391, 0, 12, 0, 7, 0, 100, 513, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Lathoric the Black - On Evade - Despawn'),
 --
-(8400, 0, 0, 1, 38, 0, 100, 512, 1, 1, 0, 0, 0, 0, 19, 256, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                 'Obsidion - On Data Set - Remove Unattackable Flags'),
-(8400, 0, 1, 2, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 91, 7, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                   'Obsidion - Linked - Set Bytes_1'),
-(8400, 0, 2, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0, 21, 100, 0, 0, 0, 0, 0, 0, 0,                'Obsidion - Linked - Attack Nearest Player'),
-(8400, 0, 3, 0, 7, 0, 100, 512, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Obsidion - On Evade - Despawn'),
-(8400, 0, 4, 0, 0, 0, 100, 512, 7000, 11000, 12000, 16000, 0, 0, 11, 12734, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Obsidion - In Combat - Cast Ground Smash'),
-(8400, 0, 5, 0, 9, 0, 100, 512, 0, 0, 15000, 21000, 0, 5, 11, 10101, 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,        'Obsidion - Within 0-5 Range - Cast Knock Away'),
+(8400, 0, 0, 1, 38, 0, 100, 512, 1, 1, 0, 0, 0, 0, 19, 256, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Obsidion - On Data Set - Remove Unattackable Flags'),
+(8400, 0, 1, 2, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 91, 7, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Obsidion - Linked - Set Bytes_1'),
+(8400, 0, 2, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0, 21, 100, 0, 0, 0, 0, 0, 0, 0,                 'Obsidion - Linked - Attack Nearest Player'),
+(8400, 0, 3, 0, 7, 0, 100, 512, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                     'Obsidion - On Evade - Despawn'),
+(8400, 0, 4, 0, 0, 0, 100, 512, 7000, 11000, 12000, 16000, 0, 0, 11, 12734, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,  'Obsidion - In Combat - Cast Ground Smash'),
+(8400, 0, 5, 0, 9, 0, 100, 512, 0, 0, 15000, 21000, 0, 5, 11, 10101, 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,         'Obsidion - Within 0-5 Range - Cast Knock Away'),
+--
+(148498, 1, 0, 1, 62, 0, 100, 0, 1282, 0, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,                 'Altar of Suntara - On Gossip Option 0 Selected - Close Gossip'),
+(148498, 1, 1, 2, 61, 0, 100, 0,0,0,0,0,0,0, 12, 8391, 4, 90000, 0,0,0, 8, 0,0,0,0, -6460.53, -1267.63, 180.782, 1.89, 'Altar of Suntara - On Gossip Option 0 Selected - Summon Creature \'Lathoric the Black\''),
+(148498, 1, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 105, 4, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                   'Altar of Suntara - On Link - Add Gameobject Flags Interact Condition'),
+(148498, 1, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 67, 1, 300000, 300000, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,          'Altar of Suntara - On Link - Create Timed Event 1'),
+(148498, 1, 4, 0, 59, 0, 100, 0, 1, 0, 0, 0, 0, 0, 106, 4, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                   'Altar of Suntara - On Update - Remove Gameobject Flags Interact Condition'),
 --
 (839101, 9, 0, 0, 0, 0, 100, 257, 0, 0, 0, 0, 0, 0, 69, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, -6475.47, -1242.28, 180.19, 3.58,          'Script9 - On Reset - Move to Altar of Suntara'),
 (839101, 9, 1, 0, 0, 0, 100, 1, 0, 0, 0, 0, 0, 0, 12, 8421, 3, 45000, 0, 0, 0, 8, 0, 0, 0, 0, -6481.13, -1237.45, 180.068, 5.10443, 'Script9 - On Reset - Spawn Dorius'),


### PR DESCRIPTION
the Dying Archaeologist had smartAI that spawned Lathoric the Black on quest accept.
in a party this caused a multi spawn

I've removed this SAI.

On quest accept nothing happens yet.
You have to use the Altar of Suntara to start the event.
