### PR TITLE
Progression 2 required for BWL

### DIFF
--- a/src/IndividualProgression.h
+++ b/src/IndividualProgression.h
@@ -229,8 +229,8 @@ enum ShatteredSunOffensive
 enum ProgressionState : uint8         // Progression stands for what has been completed
 {
     PROGRESSION_START           = 0,
-    PROGRESSION_MOLTEN_CORE     = 1,  // BWL available
-    PROGRESSION_ONYXIA          = 2,
+    PROGRESSION_MOLTEN_CORE     = 1,
+    PROGRESSION_ONYXIA          = 2,  // BWL available
     PROGRESSION_BLACKWING_LAIR  = 3,  // ZG, AQ War effort, AQ quest line
     PROGRESSION_PRE_AQ          = 4,  // AQ gates open, raids available, AQ outdoors war
     PROGRESSION_AQ_WAR          = 5,  // AQ gates open, raids, Field Duty quests and all Cenarion Hold npcs available

--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -166,9 +166,9 @@ public:
         if (!sIndividualProgression->enabled || player->IsGameMaster() || !sIndividualProgression->isNormalAccount(player))
             return true;
 
-        if (mapid == MAP_BLACKWING_LAIR && !sIndividualProgression->hasPassedProgression(player, PROGRESSION_MOLTEN_CORE))
+        if (mapid == MAP_BLACKWING_LAIR && !sIndividualProgression->hasPassedProgression(player, PROGRESSION_ONYXIA))
         {
-            ChatHandler(player->GetSession()).PSendSysMessage("Progression Level Required = |cff00ffff{}|r", PROGRESSION_MOLTEN_CORE);
+            ChatHandler(player->GetSession()).PSendSysMessage("Progression Level Required = |cff00ffff{}|r", PROGRESSION_ONYXIA);
             return false;
         }
         if (mapid == MAP_ONYXIAS_LAIR)


### PR DESCRIPTION
if you wanted to limit the server to only Molten Core and Onyxia, that was not possible.

you could enter BWL at progression level 1.
and setting the progression limit to 0 disabled the progression limit.

this PR solves this with changing the progression level requirements for BWL to 2.
Now you can limit your server to MC and Onyxia by setting your limit to 1.

It doesn't really matter anyways, I think EVERYONE kills Onyxia before stepping inside BWL.