### PR TITLE
limit Horde paladin spells to expansion

### DIFF
--- a/optional/sql/world/zz_optional_limit_spells_to_expansion.sql
+++ b/optional/sql/world/zz_optional_limit_spells_to_expansion.sql
@@ -9,10 +9,10 @@ UPDATE `trainer_spell` SET `ReqLevel` = 62 WHERE `TrainerId` = 1 AND `SpellId` =
 UPDATE `trainer_spell` SET `ReqLevel` = 62 WHERE `TrainerId` = 2 AND `SpellId` = 34428;  -- Victory Rush, level 6 -> 62
 
 -- Paladin
-UPDATE `trainer_spell` SET `ReqLevel` = 61 WHERE `TrainerId` = 3 AND `SpellId` = 31789;  -- Righteous Defense, level 14 -> 61
-UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 3 AND `SpellId` = 53407;  -- Judgement of Justice, level 28 -> 71
-UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 3 AND `SpellId` = 53408;  -- Judgement of Wisdom, level 12 -> 71
-UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 3 AND `SpellId` = 62124;  -- Hand of Reckoning, level 16 -> 71
+UPDATE `trainer_spell` SET `ReqLevel` = 61 WHERE `TrainerId` IN (3, 4) AND `SpellId` = 31789;  -- Righteous Defense, level 14 -> 61
+UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` IN (3, 4) AND `SpellId` = 53407;  -- Judgement of Justice, level 28 -> 71
+UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` IN (3, 4) AND `SpellId` = 53408;  -- Judgement of Wisdom, level 12 -> 71
+UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` IN (3, 4) AND `SpellId` = 62124;  -- Hand of Reckoning, level 16 -> 71
 
 -- Hunter
 UPDATE `trainer_spell` SET `ReqLevel` = 64 WHERE `TrainerId` = 7 AND `SpellId` = 34074;  -- Aspect of the Viper, level 20 -> 64


### PR DESCRIPTION
only Alliance paladin trainers were limited.

This happened because at first I was using trainerID 3 for both alliance and horde.
because I thought there was no difference.
When it turned out 1 spell was different I switched back to using trainerID 4 for horde.

But forgot to update this optional file.