### PR TITLE
Fix naxx40 stratholme entrance

### DIFF
--- a/src/naxx40Scripts/custom_gameobjects_40.cpp
+++ b/src/naxx40Scripts/custom_gameobjects_40.cpp
@@ -1,9 +1,9 @@
+#include "Player.h"
 #include "ScriptMgr.h"
 #include "ScriptedCreature.h"
 #include "SpellAuraEffects.h"
 #include "SpellScript.h"
 #include "GameObjectAI.h"
-#include "Player.h"
 #include "naxxramas.h"
 #include "IndividualProgression.h"
 
@@ -41,14 +41,10 @@ public:
                 allowed = false;
             }
 
-            if (sIndividualProgression->requireNaxxStrath)
+            if (sIndividualProgression->requireNaxxStrath && player->GetQuestStatus(NAXX40_ENTRANCE_FLAG) != QUEST_STATUS_REWARDED)
             {
-                if (player->GetQuestStatus(NAXX40_ENTRANCE_FLAG) == QUEST_STATUS_COMPLETE) {}
-                else
-                {
-                    handler.PSendSysMessage("You need to enter through Stratholme first. (RequireNaxxStrathEntrance is enabled)");
-                    allowed = false;
-                }
+                handler.PSendSysMessage("You need to enter Naxxramas through Stratholme first.");
+                allowed = false;
             }
 
             if (!sIndividualProgression->isAttuned(player))
@@ -82,14 +78,10 @@ public:
 
                     bool allowed = true;
 
-                    if (sIndividualProgression->requireNaxxStrath)
+                    if (sIndividualProgression->requireNaxxStrath && member->GetQuestStatus(NAXX40_ENTRANCE_FLAG) != QUEST_STATUS_REWARDED)
                     {
-                        if (member->GetQuestStatus(NAXX40_ENTRANCE_FLAG) == QUEST_STATUS_COMPLETE) {}
-                        else
-                        {
-                            handler.PSendSysMessage("|cff00ffff{}|r needs to enter through Stratholme first. (RequireNaxxStrathEntrance is enabled)", member->GetName());
-                            allowed = false;
-                        }
+                        handler.PSendSysMessage("|cff00ffff{}|r needs to enter Naxxramas through Stratholme first.", member->GetName());
+                        allowed = false;
                     }
 
                     if (sIndividualProgression->hasPassedProgression(member, PROGRESSION_TBC_TIER_5)) // death knights

--- a/src/naxx40Scripts/custom_scripts_40.cpp
+++ b/src/naxx40Scripts/custom_scripts_40.cpp
@@ -32,7 +32,8 @@ public:
         // Do not allow entrance to Naxx 40 from Northrend
         if (group && group->GetDifficulty(true) == RAID_DIFFICULTY_10MAN_HEROIC)
             group->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_NORMAL);
-        else if (player->GetDifficulty(true) == RAID_DIFFICULTY_10MAN_HEROIC)
+
+        if (player->GetDifficulty(true) == RAID_DIFFICULTY_10MAN_HEROIC)
             player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_NORMAL);
 
         switch (areaTrigger->entry)

--- a/src/naxx40Scripts/custom_scripts_40.cpp
+++ b/src/naxx40Scripts/custom_scripts_40.cpp
@@ -4,6 +4,7 @@
 #include "SpellAuraEffects.h"
 #include "SpellScript.h"
 #include "naxxramas.h"
+#include "IndividualProgression.h"
 
 class NaxxPlayerScript : public PlayerScript
 {
@@ -26,13 +27,14 @@ public:
 
     bool OnTrigger(Player* player, AreaTrigger const* areaTrigger) override
     {
+        Group* group = player->GetGroup();
+
         // Do not allow entrance to Naxx 40 from Northrend
-        // Change 10 man heroic to regular 10 man, as when 10 man heroic is not available
-        Difficulty diff = player->GetGroup() ? player->GetGroup()->GetDifficulty(true) : player->GetDifficulty(true);
-        if (diff == RAID_DIFFICULTY_10MAN_HEROIC)
-        {
+        if (group && group->GetDifficulty(true) == RAID_DIFFICULTY_10MAN_HEROIC)
+            group->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_NORMAL);
+        else if (player->GetDifficulty(true) == RAID_DIFFICULTY_10MAN_HEROIC)
             player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_NORMAL);
-        }
+
         switch (areaTrigger->entry)
         {
             // Naxx 10 and 25 entrances
@@ -49,6 +51,7 @@ public:
                 player->TeleportTo(533, 2992.5f, -3434.42f, 293.94f, 3.13f);
                 break;
         }
+
         return true;
     }
 };
@@ -95,9 +98,27 @@ public:
         if (player->IsGameMaster())
             return;
 
-        // Check if mapId equals to Naxxramas (mapId: 533)
-        if (map->GetId() != 533)
+        if (map->GetId() != 533)  // Check if mapId equals to Naxxramas (mapId: 533)
             return;
+
+        if (!sIndividualProgression->requireNaxxStrath)
+            return;
+
+        if (player->GetLevel() > 70)
+            return;
+
+        if (sIndividualProgression->hasPassedProgression(player, PROGRESSION_TBC_TIER_5)) // Death Knights
+            return;
+
+        if (!sIndividualProgression->isAttuned(player))
+            return;
+
+        Group* group = player->GetGroup();
+
+        if (group)
+            group->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+
+        player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
 
         // Cast on player Naxxramas Entry Flag Trigger DND - Classic (spellID: 29296)
         if (player->GetQuestStatus(NAXX40_ENTRANCE_FLAG) != QUEST_STATUS_REWARDED)


### PR DESCRIPTION
while in a group and entering through the entrance to Naxxramas in the back of Stratholme
you could still end up in the wotlk version of Naxxramas.

this should fix that.

this also fixes an issue at the teleport crystal in Plaguewoods 
with altbots not getting teleported inside naxx40 after you
and with `IndividualProgression.RequireNaxxStrathEntrance` enabled.