### PR TITLE
fix duplicate archers in tower/bunker

### DIFF
--- a/data/sql/world/base/av.sql
+++ b/data/sql/world/base/av.sql
@@ -3605,9 +3605,11 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (13358, 0, 0, 0, 1, 0, 100, 513, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Stormpike Bowman - Out of Combat - Disable Combat Movement (No Repeat)'),
 (13358, 0, 1, 0, 10, 0, 100, 0, 0, 80, 2300, 3900, 0, 0, 11, 22121, 64, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,         'Stormpike Bowman - Within 0-80 Range - Cast Shoot'), -- OOC
 (13358, 0, 2, 0, 0, 0, 100, 0, 0, 0, 2300, 3900, 0, 0, 11, 22121, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Stormpike Bowman - Within 0-80 Range - Cast Shoot'), -- IC
+(13358, 0, 3, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 26, 1, 0, 0, 0, 0, 0, 0, 0,                    'Stormpike Bowman - On Respawn - Despawn nearby Stormpike Bowman'),
 (13359, 0, 0, 0, 1, 0, 100, 513, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Frostwolf Bowman - Out of Combat - Disable Combat Movement (No Repeat)'),
 (13359, 0, 1, 0, 10, 0, 100, 0, 0, 80, 2300, 3900, 1, 0, 11, 22121, 64, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,         'Frostwolf Bowman - Within 0-80 Range - Cast Shoot'), -- OOC
 (13359, 0, 2, 0, 0, 0, 100, 0, 0, 0, 2300, 3900, 0, 0, 11, 22121, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Frostwolf Bowman - Within 0-80 Range - Cast Shoot'), -- IC
+(13359, 0, 3, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 26, 1, 0, 0, 0, 0, 0, 0, 0,                    'Frostwolf Bowman - On Respawn - Despawn nearby Frostwolf Bowman'),
 --
 (14282, 0, 0, 0, 25, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 8876, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Frostwolf Bloodhound - In Combat - Cast Thrash'),
 (14283, 0, 0, 0, 25, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 8876, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Stormpike Owl - In Combat - Cast Thrash'),


### PR DESCRIPTION
if a tower or bunker was taken while keeping some of the archers alive
when it was then defended by the other team a new set of archers was spawned on top of the surviving archers

now a newly spawned archer will check for an existing archer nearby and despawn it if there is one.