### PR TITLE
Ironforge various fixes

### DIFF
--- a/data/sql/world/base/zone_ironforge.sql
+++ b/data/sql/world/base/zone_ironforge.sql
@@ -198,35 +198,27 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`,
 (6031002, 9, 3, 0, 0, 0, 100, 0, 3900, 3900, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 4.60767,           'Tormus Deepforge - Resume His Usual Facing');
 
 -- Historian Karnik (2916) quest 724
-DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` = 291600;
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`,
-`event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`,
-`action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`,
-`target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
---
-(291600, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                        'Karnik - Remove Gossip/Questgiver'),
-(291600, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 2.30863,                  'Karnik - Face Hammertoe spot'),
-(291600, 9, 2, 0, 0, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 11, 4985, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,               'Karnik - Cast Summon Hammertoe''s Spirit'),
-(291600, 9, 3, 0, 0, 0, 100, 0,0,0,0,0,0,0, 12, 2915, 3, 32000, 0,0,0, 8, 0,0,0, -4633.14, -1324.99, 503.383, 5.447,   'Karnik - Summon Hammertoe''s Spirit (32s, outlasts the scene)'),
-(291600, 9, 4, 0, 0, 0, 100, 0, 3300, 3300, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                   'Karnik - Say Line 2 (CMaNGOS opening, was missing)'),
-(291600, 9, 5, 0, 0, 0, 100, 0, 7000, 7000, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 19, 2915, 0, 0, 0, 0, 0, 0,               'Hammertoe''s Spirit - Say Line 0'),
-(291600, 9, 6, 0, 0, 0, 100, 0, 5000, 5000, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                   'Karnik - Say Line 0'),
-(291600, 9, 7, 0, 0, 0, 100, 0, 5200, 5200, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 19, 2915, 0, 0, 0, 0, 0, 0,               'Hammertoe''s Spirit - Say Line 1'),
-(291600, 9, 8, 0, 0, 0, 100, 0, 7000, 7000, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                   'Karnik - Say Line 1'),
-(291600, 9, 9, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 1.76278,                  'Karnik - Restore facing'),
-(291600, 9, 10, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 82, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                       'Karnik - Add Gossip/Questgiver');
-
--- Historian Karnik (2916) quest 3448 accept - one line, three seconds later
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 2916;
-DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` = 2916002;
+DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` IN (2916001, 2916002);
 
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`,
 `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`,
 `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`,
 `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 --
-(2916, 0, 1, 0, 19, 0, 100, 0, 3448, 0, 0, 0, 0, 0, 80, 2916002, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                'Historian Karnik - On Quest 3448 Accepted - Run Script'),
+(2916, 0, 1, 0, 19, 0, 100, 0, 3448, 0, 0, 0, 0, 0, 80, 291602, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                 'Historian Karnik - On Quest 3448 Accepted - Run Script'),
 --
+(2916001, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                       'Historian Karnik - Remove Gossip/Questgiver'),
+(2916001, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 2.30863,                 'Historian Karnik - Face Hammertoe spot'),
+(2916001, 9, 2, 0, 0, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 11, 4985, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,              'Historian Karnik - Cast Summon Hammertoe''s Spirit'),
+(2916001, 9, 3, 0, 0, 0, 100, 0,0,0,0,0,0,0, 12, 2915, 3, 32000, 0,0,0, 8, 0,0,0, -4633.14, -1324.99, 503.383, 5.447,  'Historian Karnik - Summon Hammertoe''s Spirit (32s, outlasts the scene)'),
+(2916001, 9, 4, 0, 0, 0, 100, 0, 3300, 3300, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                  'Historian Karnik - Say Line 2 (CMaNGOS opening, was missing)'),
+(2916001, 9, 5, 0, 0, 0, 100, 0, 7000, 7000, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 19, 2915, 0, 0, 0, 0, 0, 0,              'Hammertoe Spirit - Say Line 0'),
+(2916001, 9, 6, 0, 0, 0, 100, 0, 5000, 5000, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                  'Historian Karnik - Say Line 0'),
+(2916001, 9, 7, 0, 0, 0, 100, 0, 5200, 5200, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 19, 2915, 0, 0, 0, 0, 0, 0,              'Hammertoe Spirit - Say Line 1'),
+(2916001, 9, 8, 0, 0, 0, 100, 0, 7000, 7000, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                  'Historian Karnik - Say Line 1'),
+(2916001, 9, 9, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 1.76278,                 'Historian Karnik - Restore facing'),
+(2916001, 9, 10, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 82, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                      'Historian Karnik - Add Gossip/Questgiver'),
 (2916002, 9, 0, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                  'Historian Karnik - Say Line 3');
 
 -- Klockmort Spannerspan (6169) quest 1708 - steps to his bench, works, returns and reports.
@@ -385,7 +377,6 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`,
 (2790001, 9, 5, 0, 0, 0, 100, 0, 5600, 5600, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 1.26,              'Grand Mason Marblesten - Turn Around (away from the memorial)'),
 (2790001, 9, 6, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                        'Grand Mason Marblesten - Say Line 2 (guards will be along)'),
 (2790001, 9, 7, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 5, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                  'Grand Mason Marblesten - Emote Bow'),
---
 (2790002, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 17, 233, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                     'Grand Mason Marblesten - Restore His Working Animation (addon emote 233)'),
 (2790002, 9, 1, 0, 0, 0, 100, 0, 500, 500, 0, 0, 0, 0, 232, 27900, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,              'Grand Mason Marblesten - Resume His Ambient Path (repeating)'),
 (2790002, 9, 2, 0, 0, 0, 100, 0, 10, 10, 0, 0, 0, 0, 82, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                     'Grand Mason Marblesten - Add Questgiver Flag'),

--- a/data/sql/world/base/zone_ironforge.sql
+++ b/data/sql/world/base/zone_ironforge.sql
@@ -36,3 +36,316 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `equipment_id`, `position_x`, `posi
 (88249,  35007, 0, 1, -5040.18, -1263.17, 510.325, 4.46067,  120, 1, 1), -- Lixa Felflinger <Battlemaster>
 (208055, 35025, 0, 1, -5036.95, -1264.96, 510.325, 3.85973,  120, 1, 0), -- Lynette Bracer <Isle of Conquest Battlemaster>
 (88248,  35600, 0, 1, -5035.64, -1267.93, 510.324, 3.29044,  300, 1, 1); -- Arcanist Laniria <Wintergrasp Battle-Mage>
+
+-- Myra Tyrngaarde - bread vendor lines
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 5109;
+
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 5109;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(5109, 0, 0, 0, 1, 0, 100, 0, 1000, 15000, 40000, 60000, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Myra Tyrngaarde - Out of Combat - Say Random Line (group 0)');
+
+-- AzerothCore base creature_addon rows, restored
+DELETE FROM `creature_addon` WHERE `guid` = 122;
+INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
+(122, 1220, 0, 0, 1, 0, 0, NULL);
+
+-- Grand Mason Marblesten - ambient route, keeps his mining emote
+DELETE FROM `waypoint_data` WHERE `id` = 27900;
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`) VALUES
+(27900, 1, -5033.81, -1022.23, 508.876, 3.8613, 30000, 0),
+(27900, 2, -5031.04, -1019.72, 508.876, NULL, 0, 0),
+(27900, 3, -5028.21, -1020.5, 508.876, 5.8955, 30000, 0),
+(27900, 4, -5028.75, -1022.3, 508.876, 4.3993, 30000, 0),
+(27900, 5, -5031.95, -1021.62, 508.876, NULL, 0, 0);
+INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`) VALUES
+(2790, 27900, 0, 0, 1, 233) ON DUPLICATE KEY UPDATE `path_id` = VALUES(`path_id`);
+UPDATE `creature` SET `MovementType` = 2 WHERE `guid` = 100 AND `id` = 2790;
+
+-- Bixi Wobblebonk - ambient route
+DELETE FROM `waypoint_data` WHERE `id` = 130840;
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`) VALUES
+(130840, 1, -5042.06, -1205.56, 508.901, 0.9774, 141000, 0),
+(130840, 2, -5041.97, -1204.65, 508.902, NULL, 0, 0),
+(130840, 3, -5043.87, -1203.1, 508.901, NULL, 0, 0),
+(130840, 4, -5047.12, -1198.18, 505.29, NULL, 0, 0),
+(130840, 5, -5046.6, -1195.7, 505.29, NULL, 0, 0),
+(130840, 6, -5042.16, -1193.11, 502.235, NULL, 0, 0),
+(130840, 7, -5039.25, -1194.53, 502.235, NULL, 0, 0),
+(130840, 8, -5038.03, -1197.81, 502.235, NULL, 0, 0),
+(130840, 9, -5039.82, -1199.59, 502.235, 3.6, 5000, 0),
+(130840, 10, -5038.39, -1203.96, 502.236, 5.2, 7000, 0),
+(130840, 11, -5037.77, -1202.85, 502.236, NULL, 0, 0),
+(130840, 12, -5038.17, -1199.26, 502.236, NULL, 0, 0),
+(130840, 13, -5039.39, -1194.18, 502.236, NULL, 0, 0),
+(130840, 14, -5042.25, -1193.52, 502.236, NULL, 0, 0),
+(130840, 15, -5046.5, -1195.73, 505.29, NULL, 0, 0),
+(130840, 16, -5046.87, -1198.24, 505.29, NULL, 0, 0),
+(130840, 17, -5043.92, -1203.21, 508.901, NULL, 0, 0),
+(130840, 18, -5041.46, -1207.59, 508.901, NULL, 0, 0),
+(130840, 19, -5039.81, -1208.87, 508.901, NULL, 0, 0),
+(130840, 20, -5038.46, -1208.77, 508.901, 0.2, 7000, 0),
+(130840, 21, -5039.97, -1208.48, 508.901, NULL, 0, 0),
+(130840, 22, -5041.19, -1206.04, 508.901, NULL, 0, 0),
+(130840, 23, -5040.67, -1203.27, 508.901, NULL, 0, 0),
+(130840, 24, -5040.22, -1199.8, 508.901, NULL, 0, 0),
+(130840, 25, -5040.42, -1199.26, 508.901, 2.1, 7000, 0),
+(130840, 26, -5037.57, -1199.39, 508.901, NULL, 0, 0),
+(130840, 27, -5035.08, -1198.91, 508.891, NULL, 0, 0),
+(130840, 28, -5032.73, -1197.4, 508.878, 0.5, 7000, 0),
+(130840, 29, -5037.16, -1199.98, 508.9, NULL, 0, 0),
+(130840, 30, -5039.77, -1202.4, 508.901, NULL, 0, 0);
+INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`) VALUES
+(13084, 130840, 0, 0, 1, 0) ON DUPLICATE KEY UPDATE `path_id` = VALUES(`path_id`);
+UPDATE `creature` SET `MovementType` = 2 WHERE `guid` = 89 AND `id` = 13084;
+
+-- AzerothCore base creature_text rows, restored
+DELETE FROM `creature_text` WHERE (`CreatureID`, `GroupID`) IN ((5109,0));
+INSERT INTO `creature_text` VALUES
+(5109,0,0,'Fresh Bread! Get your oven fresh bread here!',12,7,100,0,0,0,4014,0,'Myra Tyrngaarde'),
+(5109,0,1,'Fresh bread for sale!',12,7,100,0,0,0,4013,0,'Myra Tyrngaarde'),
+(5109,0,2,'Come get yer fresh bread!',12,7,100,0,0,0,4015,0,'Myra Tyrngaarde');
+
+
+-- ---------------------------------------------------------------------------
+-- Quest scenes
+-- ---------------------------------------------------------------------------
+
+-- Lines AzerothCore never stored
+DELETE FROM `creature_text` WHERE (`CreatureID`, `GroupID`) IN ((2916,2), (2916,3), (8507,0));
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(2916, 2, 0, 'Hammertoe, you''re as smart as you were stubborn in life and even in death. What can you tell me, ole friend?', 12, 0, 100, 0, 0, 0, 917, 0, 'Historian Karnik - quest 724 opening line'),
+(2916, 3, 0, 'Oh, $n, wait a minute! There''s one more thing! Come back!', 12, 0, 100, 0, 0, 0, 4451, 0, 'Historian Karnik - quest 3448 accept'),
+(8507, 0, 0, 'Oh, $n, wait a minute! There''s one more thing! Come back!', 12, 0, 100, 22, 0, 0, 4451, 0, 'Tymor - quest 3449 accept, carries the shout emote');
+
+
+-- Sara Balloo - quest 637 scene, paced with emotes
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 2695;
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 2695;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(2695, 0, 0, 0, 20, 0, 100, 0, 637, 0, 0, 0, 0, 0, 80, 2695001, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Sara Balloo - On Quest 637 Rewarded - Run Script');
+DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` = 2695001;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(2695001, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Sara Balloo - Set Active'),
+(2695001, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Sara Balloo - Remove Questgiver Flag'),
+(2695001, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Sara Balloo - Say Line 0'),
+(2695001, 9, 3, 0, 0, 0, 100, 0, 6000, 6000, 0, 0, 0, 0, 5, 15, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Sara Balloo - Emote Roar'),
+(2695001, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Sara Balloo - Say Line 1'),
+(2695001, 9, 5, 0, 0, 0, 100, 0, 4000, 4000, 0, 0, 0, 0, 5, 18, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Sara Balloo - Emote Cry'),
+(2695001, 9, 6, 0, 0, 0, 100, 0, 5000, 5000, 0, 0, 0, 0, 5, 20, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Sara Balloo - Emote Beg'),
+(2695001, 9, 7, 0, 0, 0, 100, 0, 5000, 5000, 0, 0, 0, 0, 82, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Sara Balloo - Add Questgiver Flag'),
+(2695001, 9, 8, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Sara Balloo - Remove Active');
+
+
+-- Tymor - quest 3449 accept line
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 8507;
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 8507;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(8507, 0, 0, 0, 19, 0, 100, 0, 3449, 0, 0, 0, 0, 0, 80, 8507001, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tymor - On Quest 3449 Accepted - Run Script');
+DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` = 8507001;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+-- Shout rides on the text row's Emote so it goes out with the line, not after it
+(8507001, 9, 0, 0, 0, 0, 100, 0, 500, 500, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tymor - Say Line 0 (emote 22 rides on the text row)');
+
+
+-- Muren Stormpike - quest 1680 accept: turns, waves, speaks, turns back
+-- Link chain, not a timed list - a quest-accept event is synchronous (doc 2q)
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 6114;
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 6114;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(6114, 0, 0, 1, 19, 0, 100, 0, 1680, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 'Muren Stormpike - On Quest 1680 Accepted - Face Player'),
+(6114, 0, 1, 2, 61, 0, 100, 0,    0, 0, 0, 0, 0, 0,  5, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Muren Stormpike - Link - Emote Wave'),
+(6114, 0, 2, 3, 61, 0, 100, 0,    0, 0, 0, 0, 0, 0,  1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Muren Stormpike - Link - Say Line 0'),
+(6114, 0, 3, 0, 61, 0, 100, 0,    0, 0, 0, 0, 0, 0, 80, 6114001, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Muren Stormpike - Link - Run Script (turn back)');
+DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` = 6114001;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(6114001, 9, 0, 0, 0, 0, 100, 0, 4000, 4000, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0.84, 'Muren Stormpike - Turn Back To Post');
+
+-- Tormus Deepforge - quest 1681: walks to The Great Anvil, works, walks back, reports
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 6031;
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 6031;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(6031, 0, 0, 1, 20, 0, 100, 0, 1681, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tormus Deepforge - On Quest 1681 Rewarded - Walk, do not run'),
+(6031, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 64, 1, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 'Tormus Deepforge - Link - Remember the player'),
+(6031, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tormus Deepforge - Link - Say Line 0 (begins to work)'),
+(6031, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 601, 0, 0, 0, 0, 0, 8, 0, 0, 0, -4798.0127, -1105.1676, 499.6052, 0, 'Tormus Deepforge - Link - Walk To The Great Anvil'),
+(6031, 0, 4, 0, 34, 0, 100, 0, 8, 601, 0, 0, 0, 0, 80, 6031001, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tormus Deepforge - On Reaching The Anvil - Run Script'),
+(6031, 0, 5, 0, 34, 0, 100, 0, 8, 602, 0, 0, 0, 0, 80, 6031002, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tormus Deepforge - On Returning Home - Run Script');
+DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` IN (6031001, 6031002);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(6031001, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 4.15396, 'Tormus Deepforge - Face The Anvil'),
+(6031001, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 17, 173, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tormus Deepforge - Emote State Work'),
+(6031001, 9, 2, 0, 0, 0, 100, 0, 4900, 4900, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tormus Deepforge - Clear Emote State'),
+(6031001, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 602, 0, 0, 0, 0, 0, 8, 0, 0, 0, -4793.38, -1098.17, 498.89, 0, 'Tormus Deepforge - Walk Back To His Post'),
+(6031002, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 12, 1, 0, 0, 0, 0, 0, 0, 'Tormus Deepforge - Face The Player'),
+(6031002, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 5, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tormus Deepforge - Emote Talk'),
+(6031002, 9, 2, 0, 0, 0, 100, 0, 100, 100, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tormus Deepforge - Say Line 1 (I am finished)'),
+(6031002, 9, 3, 0, 0, 0, 100, 0, 3900, 3900, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 4.60767, 'Tormus Deepforge - Resume His Usual Facing');
+
+
+-- Historian Karnik - quest 724: adds his opening line to Hammertoe and holds the summon for it
+DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` = 291600;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(291600, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Karnik - Remove Gossip/Questgiver'),
+(291600, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 2.30863, 'Karnik - Face Hammertoe spot'),
+(291600, 9, 2, 0, 0, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 11, 4985, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Karnik - Cast Summon Hammertoe''s Spirit'),
+(291600, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 12, 2915, 3, 32000, 0, 0, 0, 8, 0, 0, 0, -4633.14, -1324.99, 503.383, 5.44702, 'Karnik - Summon Hammertoe''s Spirit (32s, outlasts the scene)'),
+(291600, 9, 4, 0, 0, 0, 100, 0, 3300, 3300, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Karnik - Say Line 2 (CMaNGOS opening, was missing)'),
+(291600, 9, 5, 0, 0, 0, 100, 0, 7000, 7000, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 19, 2915, 0, 0, 0, 0, 0, 0, 'Hammertoe''s Spirit - Say Line 0'),
+(291600, 9, 6, 0, 0, 0, 100, 0, 5000, 5000, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Karnik - Say Line 0'),
+(291600, 9, 7, 0, 0, 0, 100, 0, 5200, 5200, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 19, 2915, 0, 0, 0, 0, 0, 0, 'Hammertoe''s Spirit - Say Line 1'),
+(291600, 9, 8, 0, 0, 0, 100, 0, 7000, 7000, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Karnik - Say Line 1'),
+(291600, 9, 9, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 1.76278, 'Karnik - Restore facing'),
+(291600, 9, 10, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 82, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Karnik - Add Gossip/Questgiver');
+
+-- Historian Karnik - quest 3448 accept line
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 2916 AND `id` = 1;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(2916, 0, 1, 0, 19, 0, 100, 0, 3448, 0, 0, 0, 0, 0, 80, 2916002, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Historian Karnik - On Quest 3448 Accepted - Run Script');
+DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` = 2916002;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(2916002, 9, 0, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Historian Karnik - Say Line 3');
+
+-- Klockmort Spannerspan - quest 1708: steps to his bench, works, returns and reports
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 6169;
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 6169;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(6169, 0, 0, 1, 20, 0, 100, 0, 1708, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - On Quest 1708 Rewarded - Walk, do not run'),
+(6169, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 64, 1, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Link - Remember the player'),
+(6169, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Link - Set Active'),
+(6169, 0, 3, 4, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Link - Remove Questgiver Flag'),
+(6169, 0, 4, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 611, 0, 0, 0, 0, 0, 8, 0, 0, 0, -4814.8901, -1250.52, 501.926, 0, 'Klockmort Spannerspan - Link - Walk To The Bench'),
+(6169, 0, 5, 0, 34, 0, 100, 0, 8, 611, 0, 0, 0, 0, 80, 6169001, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - On Reaching The Bench - Run Script'),
+(6169, 0, 6, 0, 34, 0, 100, 0, 8, 612, 0, 0, 0, 0, 80, 6169002, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - On Returning Home - Run Script');
+DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` IN (6169001, 6169002);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(6169001, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 17, 173, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Emote State Work'),
+(6169001, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Say Line 0 (begins to work)'),
+(6169001, 9, 2, 0, 0, 0, 100, 0, 6000, 6000, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Clear Emote State'),
+(6169001, 9, 3, 0, 0, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Say Line 1 (it is done)'),
+(6169001, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 5, 4, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Emote Cheer'),
+(6169001, 9, 5, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 12, 1, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Face The Player'),
+(6169001, 9, 6, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 0, 69, 612, 0, 0, 0, 0, 0, 8, 0, 0, 0, -4812.48, -1250.62, 501.947, 0, 'Klockmort Spannerspan - Walk Back To His Post'),
+(6169002, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 4.6251, 'Klockmort Spannerspan - Resume His Usual Facing'),
+(6169002, 9, 1, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 0, 82, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Add Questgiver Flag'),
+(6169002, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Clear Active');
+
+-- Talvash del Kissel - quest 2204: fetches a spell focus from his house and repairs the necklace
+-- His id 1 row (the /train emote credit) is left alone
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 6826 AND `id` IN (2, 3);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(6826, 0, 2, 3, 20, 0, 100, 0, 2204, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - On Quest 2204 Rewarded - Walk, do not run'),
+(6826, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 80, 6826002, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Link - Run Script');
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 6826 AND `id` = 4;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(6826, 0, 4, 0, 34, 0, 100, 0, 8, 623, 0, 0, 0, 0, 80, 6826003, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - On Returning Home - Restore Facing');
+DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` IN (6826002, 6826003);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(6826002, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Set Active'),
+(6826002, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Remove Gossip/Questgiver'),
+(6826002, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Say Line 1'),
+(6826002, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 621, 0, 0, 0, 0, 0, 8, 0, 0, 0, -4574.79, -998.688, 503.657, 0, 'Talvash del Kissel - Walk To His House'),
+(6826002, 9, 4, 0, 0, 0, 100, 0, 10000, 10000, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Say Line 2'),
+(6826002, 9, 5, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Say Line 3'),
+(6826002, 9, 6, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 622, 0, 0, 0, 0, 0, 8, 0, 0, 0, -4580.4902, -993.985, 503.657, 0, 'Talvash del Kissel - Walk To The Bed'),
+(6826002, 9, 7, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 5, 5, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Emote Exclamation'),
+(6826002, 9, 8, 0, 0, 0, 100, 0, 5000, 5000, 0, 0, 0, 0, 5, 16, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Emote Kneel'),
+(6826002, 9, 9, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Say Line 4'),
+(6826002, 9, 10, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 623, 0, 0, 0, 0, 0, 8, 0, 0, 0, -4588.2998, -1001.21, 503.657, 0, 'Talvash del Kissel - Walk Back To His Post'),
+(6826002, 9, 11, 0, 0, 0, 100, 0, 5000, 5000, 0, 0, 0, 0, 11, 9795, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Cast Necklace Repair'),
+(6826002, 9, 12, 0, 0, 0, 100, 0, 8000, 8000, 0, 0, 0, 0, 82, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Add Gossip/Questgiver'),
+(6826002, 9, 13, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 5, 4, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Emote Cheer'),
+(6826002, 9, 14, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Clear Active'),
+(6826002, 9, 15, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 5, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Say Line 5'),
+(6826003, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 3.3161, 'Talvash del Kissel - Resume His Usual Facing');
+
+-- Laris Geardawdle - quest 4512: carries the slime sample over and reacts to it
+DELETE FROM `creature_text` WHERE `CreatureID` = 9616;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(9616, 0, 0, 'Incredible! Amazing! I don''t even know what this means!', 12, 0, 100, 0, 0, 0, 5447, 0, 'Laris Geardawdle - quest 4512');
+DELETE FROM `waypoints` WHERE `entry` = 96160;
+INSERT INTO `waypoints` (`entry`, `pointid`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `point_comment`) VALUES
+(96160, 1, -4691.35, -1316.52, 503.381, NULL, 1000, 'Laris Geardawdle - react'),
+(96160, 2, -4693.75, -1310.95, 503.381, NULL, 0, 'Laris Geardawdle - over'),
+(96160, 3, -4692.07, -1315.18, 503.381, NULL, 0, 'Laris Geardawdle - back'),
+(96160, 4, -4692.6, -1312.64, 503.381, 2.9321, 1000, 'Laris Geardawdle - home');
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 9616;
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 9616;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(9616, 0, 0, 1, 20, 0, 100, 0, 4512, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Laris Geardawdle - On Quest 4512 Rewarded - Walk, do not run'),
+(9616, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Laris Geardawdle - Link - Set Active'),
+(9616, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Laris Geardawdle - Link - Remove Questgiver Flag'),
+(9616, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 232, 96160, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Laris Geardawdle - Link - Start Quest Path'),
+(9616, 0, 4, 0, 108, 0, 100, 0, 1, 96160, 0, 0, 0, 0, 80, 9616001, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Laris Geardawdle - On Waypoint 1 - Run Script'),
+(9616, 0, 5, 0, 108, 0, 100, 0, 4, 96160, 0, 0, 0, 0, 80, 9616002, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Laris Geardawdle - On Waypoint 4 - Run Script');
+DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` IN (9616001, 9616002);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(9616001, 9, 0, 0, 0, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 5, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Laris Geardawdle - Emote Talk'),
+(9616001, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Laris Geardawdle - Say Line 0'),
+(9616002, 9, 0, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Laris Geardawdle - Clear Active'),
+(9616002, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 82, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Laris Geardawdle - Add Questgiver Flag');
+
+-- Curator Thorius - quest 3182: carries the horn to its display, mounts it, resumes his route
+-- Also spawns the Horn of Margol the Rager, which had a template here but no spawn
+DELETE FROM `gameobject` WHERE `guid` = 1471360;
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`) VALUES
+(1471360, 147136, 0, 1, 1, -4629.5, -1279.51, 503.381, 2.32129, 0, 0, 0.91706, 0.39875, -60, 100, 1);
+DELETE FROM `waypoints` WHERE `entry` = 82560;
+INSERT INTO `waypoints` (`entry`, `pointid`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `point_comment`) VALUES
+(82560, 1, -4652.28, -1278.88, 503.382, 5.3756, 1000, 'Curator Thorius - set off'),
+(82560, 2, -4631.19, -1278.02, 503.382, 5.4803, 22000, 'Curator Thorius - the display');
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 8256;
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 8256;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(8256, 0, 0, 1, 20, 0, 100, 0, 3182, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - On Quest 3182 Rewarded - Walk, do not run'),
+(8256, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - Link - Set Active'),
+(8256, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - Link - Say Line 1 (just the spot for this horn)'),
+(8256, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 232, 82560, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - Link - Start Quest Path'),
+(8256, 0, 4, 0, 108, 0, 100, 0, 2, 82560, 0, 0, 0, 0, 80, 8256001, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - On Reaching The Display - Run Script');
+DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` = 8256001;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(8256001, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - Say Line 2 (saving this spot)'),
+(8256001, 9, 1, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 17, 173, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - Emote State Work'),
+(8256001, 9, 2, 0, 0, 0, 100, 0, 10000, 10000, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - Clear Emote State'),
+(8256001, 9, 3, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - Say Line 3 (all done)'),
+(8256001, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 5, 4, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - Emote Cheer'),
+(8256001, 9, 5, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 70, 60, 0, 0, 0, 0, 0, 14, 1471360, 147136, 0, 0, 0, 0, 0, 'Curator Thorius - Reveal The Horn For 60s'),
+(8256001, 9, 6, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - Clear Active'),
+(8256001, 9, 7, 0, 0, 0, 100, 0, 8000, 8000, 0, 0, 0, 0, 232, 18870, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - Resume His Ambient Patrol');
+
+-- Grand Mason Marblesten - quest 689: walks down and carves the Memorial to Sully Balloo
+-- WAYPOINT_START sits on the link chain, never inside a timed action list (doc 2g)
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 2790;
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 2790;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(2790, 0, 0, 1, 20, 0, 100, 0, 689, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - On Quest 689 Rewarded - Walk, do not run'),
+(2790, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Link - Clear Emote State'),
+(2790, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Link - Set Active'),
+(2790, 0, 3, 4, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Link - Remove Questgiver Flag'),
+(2790, 0, 4, 5, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Link - Say Line 0 (get to work)'),
+(2790, 0, 5, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 232, 27901, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Link - Start Quest Path'),
+(2790, 0, 6, 0, 108, 0, 100, 0, 6, 27901, 0, 0, 0, 0, 80, 2790001, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - On Reaching The Memorial - Run Script'),
+(2790, 0, 7, 0, 108, 0, 100, 0, 11, 27901, 0, 0, 0, 0, 80, 2790002, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - On Returning To His Post - Run Script');
+-- Grand Mason Marblesten - the work scene at the memorial, then back to his ambient route
+-- Both halves are needed to restore him: repeat = 1 on the ambient path, and the addon
+-- mining emote set again by hand (doc 2q)
+DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` IN (2790001, 2790002, 2790003);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(2790001, 9, 0, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 17, 233, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Emote State Work Mining'),
+(2790001, 9, 1, 0, 0, 0, 100, 0, 5950, 5950, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Stop Working'),
+(2790001, 9, 2, 0, 0, 0, 100, 0, 50, 50, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 14, 821, 139852, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Reveal The Memorial'),
+(2790001, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Say Line 1 (there you have it)'),
+(2790001, 9, 4, 0, 0, 0, 100, 0, 400, 400, 0, 0, 0, 0, 5, 25, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Point At It (after the line, or the talk animation eats it)'),
+(2790001, 9, 5, 0, 0, 0, 100, 0, 5600, 5600, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 1.26, 'Grand Mason Marblesten - Turn Around (away from the memorial)'),
+(2790001, 9, 6, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Say Line 2 (guards will be along)'),
+(2790001, 9, 7, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 5, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Emote Bow'),
+(2790002, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 17, 233, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Restore His Working Animation (addon emote 233)'),
+(2790002, 9, 1, 0, 0, 0, 100, 0, 500, 500, 0, 0, 0, 0, 232, 27900, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Resume His Ambient Path (repeating)'),
+(2790002, 9, 2, 0, 0, 0, 100, 0, 10, 10, 0, 0, 0, 0, 82, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Add Questgiver Flag'),
+(2790002, 9, 3, 0, 0, 0, 100, 0, 5, 5, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Clear Active');
+
+-- King Magni Bronzebeard - his Brokering of Peace yell (quest 8484); group 0 already shipped
+-- Driven from src/vanillaScripts/zone_ironforge.cpp, NOT SmartAI - his ScriptName owns the
+-- AI slot, so AIName here would never run. Do not add one.
+DELETE FROM `creature_text` WHERE `CreatureID` = 2784 AND `GroupID` = 1;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(2784, 1, 0, 'Let it be known that $n - Alliance $C - has earned the undying respect of Ironforge and the Alliance as a whole.  $GHe : She; has engaged in great diplomacy with Timbermaw Hold and performed valiant actions for them on our behalf.   $GHe : She; has gone above and beyond the call of duty.  Three cheers for $n - a true hero of the Alliance!', 14, 0, 100, 5, 0, 0, 11308, 0, 'King Magni Bronzebeard - The Brokering of Peace');

--- a/data/sql/world/base/zone_ironforge.sql
+++ b/data/sql/world/base/zone_ironforge.sql
@@ -206,7 +206,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`,
 `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`,
 `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 --
-(2916, 0, 1, 0, 19, 0, 100, 0, 3448, 0, 0, 0, 0, 0, 80, 291602, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                 'Historian Karnik - On Quest 3448 Accepted - Run Script'),
+(2916, 0, 1, 0, 19, 0, 100, 0, 3448, 0, 0, 0, 0, 0, 80, 2916002, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                'Historian Karnik - On Quest 3448 Accepted - Run Script'),
 --
 (2916001, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                       'Historian Karnik - Remove Gossip/Questgiver'),
 (2916001, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 2.30863,                 'Historian Karnik - Face Hammertoe spot'),

--- a/data/sql/world/base/zone_ironforge.sql
+++ b/data/sql/world/base/zone_ironforge.sql
@@ -44,12 +44,12 @@ DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 5109;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (5109, 0, 0, 0, 1, 0, 100, 0, 1000, 15000, 40000, 60000, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Myra Tyrngaarde - Out of Combat - Say Random Line (group 0)');
 
--- AzerothCore base creature_addon rows, restored
+-- Myra: path 1220 is her own 13-node Commons circuit.
 DELETE FROM `creature_addon` WHERE `guid` = 122;
 INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
 (122, 1220, 0, 0, 1, 0, 0, NULL);
 
--- Grand Mason Marblesten - ambient route, keeps his mining emote
+-- Grand Mason Marblesten (2790) - ambient route
 DELETE FROM `waypoint_data` WHERE `id` = 27900;
 INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`) VALUES
 (27900, 1, -5033.81, -1022.23, 508.876, 3.8613, 30000, 0),
@@ -61,7 +61,7 @@ INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `b
 (2790, 27900, 0, 0, 1, 233) ON DUPLICATE KEY UPDATE `path_id` = VALUES(`path_id`);
 UPDATE `creature` SET `MovementType` = 2 WHERE `guid` = 100 AND `id` = 2790;
 
--- Bixi Wobblebonk - ambient route
+-- Bixi Wobblebonk (13084) - ambient route
 DELETE FROM `waypoint_data` WHERE `id` = 130840;
 INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`) VALUES
 (130840, 1, -5042.06, -1205.56, 508.901, 0.9774, 141000, 0),
@@ -98,7 +98,7 @@ INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `b
 (13084, 130840, 0, 0, 1, 0) ON DUPLICATE KEY UPDATE `path_id` = VALUES(`path_id`);
 UPDATE `creature` SET `MovementType` = 2 WHERE `guid` = 89 AND `id` = 13084;
 
--- AzerothCore base creature_text rows, restored
+-- Myra Tyrngaarde's three bread-vendor lines (group 0).
 DELETE FROM `creature_text` WHERE (`CreatureID`, `GroupID`) IN ((5109,0));
 INSERT INTO `creature_text` VALUES
 (5109,0,0,'Fresh Bread! Get your oven fresh bread here!',12,7,100,0,0,0,4014,0,'Myra Tyrngaarde'),
@@ -106,11 +106,7 @@ INSERT INTO `creature_text` VALUES
 (5109,0,2,'Come get yer fresh bread!',12,7,100,0,0,0,4015,0,'Myra Tyrngaarde');
 
 
--- ---------------------------------------------------------------------------
--- Quest scenes
--- ---------------------------------------------------------------------------
-
--- Lines AzerothCore never stored
+-- Lines that AzerothCore never stored
 DELETE FROM `creature_text` WHERE (`CreatureID`, `GroupID`) IN ((2916,2), (2916,3), (8507,0));
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
 (2916, 2, 0, 'Hammertoe, you''re as smart as you were stubborn in life and even in death. What can you tell me, ole friend?', 12, 0, 100, 0, 0, 0, 917, 0, 'Historian Karnik - quest 724 opening line'),
@@ -118,7 +114,7 @@ INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Lan
 (8507, 0, 0, 'Oh, $n, wait a minute! There''s one more thing! Come back!', 12, 0, 100, 22, 0, 0, 4451, 0, 'Tymor - quest 3449 accept, carries the shout emote');
 
 
--- Sara Balloo - quest 637 scene, paced with emotes
+-- Sara Balloo (2695) quest 637 - AzerothCore fired both lines at once, with no emotes
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 2695;
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 2695;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
@@ -136,19 +132,19 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (2695001, 9, 8, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Sara Balloo - Remove Active');
 
 
--- Tymor - quest 3449 accept line
+-- Tymor (8507) quest 3449 accept
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 8507;
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 8507;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (8507, 0, 0, 0, 19, 0, 100, 0, 3449, 0, 0, 0, 0, 0, 80, 8507001, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tymor - On Quest 3449 Accepted - Run Script');
 DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` = 8507001;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
--- Shout rides on the text row's Emote so it goes out with the line, not after it
+-- One row, not two: CreatureTextMgr::SendChat fires the row's Emote immediately before the
+-- chat packet, so the shout and the line go out together instead of the line clipping it.
 (8507001, 9, 0, 0, 0, 0, 100, 0, 500, 500, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tymor - Say Line 0 (emote 22 rides on the text row)');
 
 
--- Muren Stormpike - quest 1680 accept: turns, waves, speaks, turns back
--- Link chain, not a timed list - a quest-accept event is synchronous (doc 2q)
+-- Muren Stormpike (6114) quest 1680 accept
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 6114;
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 6114;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
@@ -160,7 +156,7 @@ DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` = 6114001;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (6114001, 9, 0, 0, 0, 0, 100, 0, 4000, 4000, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0.84, 'Muren Stormpike - Turn Back To Post');
 
--- Tormus Deepforge - quest 1681: walks to The Great Anvil, works, walks back, reports
+-- Tormus Deepforge (6031) quest 1681 - walks to The Great Anvil, works, walks back, reports.
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 6031;
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 6031;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
@@ -182,7 +178,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (6031002, 9, 3, 0, 0, 0, 100, 0, 3900, 3900, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 4.60767, 'Tormus Deepforge - Resume His Usual Facing');
 
 
--- Historian Karnik - quest 724: adds his opening line to Hammertoe and holds the summon for it
+-- Historian Karnik (2916) quest 724
 DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` = 291600;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (291600, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Karnik - Remove Gossip/Questgiver'),
@@ -197,7 +193,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (291600, 9, 9, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 1.76278, 'Karnik - Restore facing'),
 (291600, 9, 10, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 82, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Karnik - Add Gossip/Questgiver');
 
--- Historian Karnik - quest 3448 accept line
+-- Historian Karnik (2916) quest 3448 accept - one line, three seconds later
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 2916 AND `id` = 1;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (2916, 0, 1, 0, 19, 0, 100, 0, 3448, 0, 0, 0, 0, 0, 80, 2916002, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Historian Karnik - On Quest 3448 Accepted - Run Script');
@@ -205,7 +201,7 @@ DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` = 2916002;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (2916002, 9, 0, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Historian Karnik - Say Line 3');
 
--- Klockmort Spannerspan - quest 1708: steps to his bench, works, returns and reports
+-- Klockmort Spannerspan (6169) quest 1708 - steps to his bench, works, returns and reports.
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 6169;
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 6169;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
@@ -229,8 +225,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (6169002, 9, 1, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 0, 82, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Add Questgiver Flag'),
 (6169002, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Clear Active');
 
--- Talvash del Kissel - quest 2204: fetches a spell focus from his house and repairs the necklace
--- His id 1 row (the /train emote credit) is left alone
+-- Talvash del Kissel (6826) quest 2204 - fetches a spell focus from his house and repairs the necklace.
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 6826 AND `id` IN (2, 3);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (6826, 0, 2, 3, 20, 0, 100, 0, 2204, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - On Quest 2204 Rewarded - Walk, do not run'),
@@ -258,7 +253,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (6826002, 9, 15, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 5, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Say Line 5'),
 (6826003, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 3.3161, 'Talvash del Kissel - Resume His Usual Facing');
 
--- Laris Geardawdle - quest 4512: carries the slime sample over and reacts to it
+-- Laris Geardawdle (9616) quest 4512 - carries the slime sample over and reacts to it.
 DELETE FROM `creature_text` WHERE `CreatureID` = 9616;
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
 (9616, 0, 0, 'Incredible! Amazing! I don''t even know what this means!', 12, 0, 100, 0, 0, 0, 5447, 0, 'Laris Geardawdle - quest 4512');
@@ -284,8 +279,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (9616002, 9, 0, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Laris Geardawdle - Clear Active'),
 (9616002, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 82, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Laris Geardawdle - Add Questgiver Flag');
 
--- Curator Thorius - quest 3182: carries the horn to its display, mounts it, resumes his route
--- Also spawns the Horn of Margol the Rager, which had a template here but no spawn
+-- Curator Thorius (8256) quest 3182 - carries the horn to its display and mounts it.
 DELETE FROM `gameobject` WHERE `guid` = 1471360;
 INSERT INTO `gameobject` (`guid`, `id`, `map`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`) VALUES
 (1471360, 147136, 0, 1, 1, -4629.5, -1279.51, 503.381, 2.32129, 0, 0, 0.91706, 0.39875, -60, 100, 1);
@@ -312,8 +306,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (8256001, 9, 6, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - Clear Active'),
 (8256001, 9, 7, 0, 0, 0, 100, 0, 8000, 8000, 0, 0, 0, 0, 232, 18870, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - Resume His Ambient Patrol');
 
--- Grand Mason Marblesten - quest 689: walks down and carves the Memorial to Sully Balloo
--- WAYPOINT_START sits on the link chain, never inside a timed action list (doc 2g)
+-- Grand Mason Marblesten (2790) quest 689 - carves the Memorial to Sully Balloo
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 2790;
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 2790;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
@@ -325,9 +318,9 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (2790, 0, 5, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 232, 27901, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Link - Start Quest Path'),
 (2790, 0, 6, 0, 108, 0, 100, 0, 6, 27901, 0, 0, 0, 0, 80, 2790001, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - On Reaching The Memorial - Run Script'),
 (2790, 0, 7, 0, 108, 0, 100, 0, 11, 27901, 0, 0, 0, 0, 80, 2790002, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - On Returning To His Post - Run Script');
--- Grand Mason Marblesten - the work scene at the memorial, then back to his ambient route
--- Both halves are needed to restore him: repeat = 1 on the ambient path, and the addon
--- mining emote set again by hand (doc 2q)
+
+-- Grand Mason Marblesten - the work scene at the memorial (node 6 of quest path 27901) and the
+-- restoration of his ambient behaviour afterwards.
 DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` IN (2790001, 2790002, 2790003);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (2790001, 9, 0, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 17, 233, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Emote State Work Mining'),
@@ -343,9 +336,15 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (2790002, 9, 2, 0, 0, 0, 100, 0, 10, 10, 0, 0, 0, 0, 82, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Add Questgiver Flag'),
 (2790002, 9, 3, 0, 0, 0, 100, 0, 5, 5, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Clear Active');
 
--- King Magni Bronzebeard - his Brokering of Peace yell (quest 8484); group 0 already shipped
--- Driven from src/vanillaScripts/zone_ironforge.cpp, NOT SmartAI - his ScriptName owns the
--- AI slot, so AIName here would never run. Do not add one.
+-- King Magni Bronzebeard 2784
+--   683  Sara Balloo's Plea     - delay 0,    broadcast 860,   text emote (ChatTypeID 2)
+--   8484 The Brokering of Peace - delay 1000, broadcast 11308, yell (ChatTypeID 1)
+--
+-- The scenes themselves are C++ in zone_ironforge.cpp: Magni carries
+-- `creature_template`.`ScriptName` = 'npc_king_magni_bronzebeard' and
+-- `CreatureAISelector::SelectAI` tests ScriptName before AIName, so `AIName` = 'SmartAI' on this
+-- entry would never run. Do NOT add one here.
+
 DELETE FROM `creature_text` WHERE `CreatureID` = 2784 AND `GroupID` = 1;
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
 (2784, 1, 0, 'Let it be known that $n - Alliance $C - has earned the undying respect of Ironforge and the Alliance as a whole.  $GHe : She; has engaged in great diplomacy with Timbermaw Hold and performed valiant actions for them on our behalf.   $GHe : She; has gone above and beyond the call of duty.  Three cheers for $n - a true hero of the Alliance!', 14, 0, 100, 5, 0, 0, 11308, 0, 'King Magni Bronzebeard - The Brokering of Peace');

--- a/data/sql/world/base/zone_ironforge.sql
+++ b/data/sql/world/base/zone_ironforge.sql
@@ -39,9 +39,12 @@ INSERT INTO `creature` (`guid`, `id`, `map`, `equipment_id`, `position_x`, `posi
 
 -- Myra Tyrngaarde - bread vendor lines
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 5109;
-
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 5109;
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`,
+`event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`,
+`action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`,
+`target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+--
 (5109, 0, 0, 0, 1, 0, 100, 0, 1000, 15000, 40000, 60000, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Myra Tyrngaarde - Out of Combat - Say Random Line (group 0)');
 
 -- Myra: path 1220 is her own 13-node Commons circuit.
@@ -50,6 +53,12 @@ INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `e
 (122, 1220, 0, 0, 1, 0, 0, NULL);
 
 -- Grand Mason Marblesten (2790) - ambient route
+UPDATE `creature` SET `MovementType` = 2 WHERE `guid` = 100 AND `id` = 2790;
+
+DELETE FROM `creature_template_addon` WHERE `entry` = 2790;
+INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`) VALUES
+(2790, 27900, 0, 0, 1, 233);
+
 DELETE FROM `waypoint_data` WHERE `id` = 27900;
 INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`) VALUES
 (27900, 1, -5033.81, -1022.23, 508.876, 3.8613, 30000, 0),
@@ -57,11 +66,14 @@ INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `positio
 (27900, 3, -5028.21, -1020.5, 508.876, 5.8955, 30000, 0),
 (27900, 4, -5028.75, -1022.3, 508.876, 4.3993, 30000, 0),
 (27900, 5, -5031.95, -1021.62, 508.876, NULL, 0, 0);
-INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`) VALUES
-(2790, 27900, 0, 0, 1, 233) ON DUPLICATE KEY UPDATE `path_id` = VALUES(`path_id`);
-UPDATE `creature` SET `MovementType` = 2 WHERE `guid` = 100 AND `id` = 2790;
 
 -- Bixi Wobblebonk (13084) - ambient route
+UPDATE `creature` SET `MovementType` = 2 WHERE `guid` = 89 AND `id` = 13084;
+
+DELETE FROM `creature_template_addon` WHERE `entry` = 13084;
+INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`) VALUES
+(13084, 130840, 0, 0, 1, 0);
+
 DELETE FROM `waypoint_data` WHERE `id` = 130840;
 INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`) VALUES
 (130840, 1, -5042.06, -1205.56, 508.901, 0.9774, 141000, 0),
@@ -94,257 +106,294 @@ INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `positio
 (130840, 28, -5032.73, -1197.4, 508.878, 0.5, 7000, 0),
 (130840, 29, -5037.16, -1199.98, 508.9, NULL, 0, 0),
 (130840, 30, -5039.77, -1202.4, 508.901, NULL, 0, 0);
-INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`) VALUES
-(13084, 130840, 0, 0, 1, 0) ON DUPLICATE KEY UPDATE `path_id` = VALUES(`path_id`);
-UPDATE `creature` SET `MovementType` = 2 WHERE `guid` = 89 AND `id` = 13084;
-
--- Myra Tyrngaarde's three bread-vendor lines (group 0).
-DELETE FROM `creature_text` WHERE (`CreatureID`, `GroupID`) IN ((5109,0));
-INSERT INTO `creature_text` VALUES
-(5109,0,0,'Fresh Bread! Get your oven fresh bread here!',12,7,100,0,0,0,4014,0,'Myra Tyrngaarde'),
-(5109,0,1,'Fresh bread for sale!',12,7,100,0,0,0,4013,0,'Myra Tyrngaarde'),
-(5109,0,2,'Come get yer fresh bread!',12,7,100,0,0,0,4015,0,'Myra Tyrngaarde');
-
 
 -- Lines that AzerothCore never stored
-DELETE FROM `creature_text` WHERE (`CreatureID`, `GroupID`) IN ((2916,2), (2916,3), (8507,0));
+DELETE FROM `creature_text` WHERE `CreatureID` IN (2916, 8507);
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(2916, 0, 0, 'Ragnaros? Terrible news indeed...', 12, 0, 100, 6, 0, 0, 956, 0, 'Historian Karnik'),
+(2916, 1, 0, 'You heard him, traveler. Speak to me again when you\'re ready to speak to Belgrum.', 12, 0, 100, 0, 0, 0, 958, 0, 'Historian Karnik'),
 (2916, 2, 0, 'Hammertoe, you''re as smart as you were stubborn in life and even in death. What can you tell me, ole friend?', 12, 0, 100, 0, 0, 0, 917, 0, 'Historian Karnik - quest 724 opening line'),
 (2916, 3, 0, 'Oh, $n, wait a minute! There''s one more thing! Come back!', 12, 0, 100, 0, 0, 0, 4451, 0, 'Historian Karnik - quest 3448 accept'),
 (8507, 0, 0, 'Oh, $n, wait a minute! There''s one more thing! Come back!', 12, 0, 100, 22, 0, 0, 4451, 0, 'Tymor - quest 3449 accept, carries the shout emote');
 
-
 -- Sara Balloo (2695) quest 637 - AzerothCore fired both lines at once, with no emotes
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 2695;
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 2695;
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(2695, 0, 0, 0, 20, 0, 100, 0, 637, 0, 0, 0, 0, 0, 80, 2695001, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Sara Balloo - On Quest 637 Rewarded - Run Script');
 DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` = 2695001;
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(2695001, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Sara Balloo - Set Active'),
-(2695001, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Sara Balloo - Remove Questgiver Flag'),
-(2695001, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Sara Balloo - Say Line 0'),
-(2695001, 9, 3, 0, 0, 0, 100, 0, 6000, 6000, 0, 0, 0, 0, 5, 15, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Sara Balloo - Emote Roar'),
-(2695001, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Sara Balloo - Say Line 1'),
-(2695001, 9, 5, 0, 0, 0, 100, 0, 4000, 4000, 0, 0, 0, 0, 5, 18, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Sara Balloo - Emote Cry'),
-(2695001, 9, 6, 0, 0, 0, 100, 0, 5000, 5000, 0, 0, 0, 0, 5, 20, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Sara Balloo - Emote Beg'),
-(2695001, 9, 7, 0, 0, 0, 100, 0, 5000, 5000, 0, 0, 0, 0, 82, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Sara Balloo - Add Questgiver Flag'),
-(2695001, 9, 8, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Sara Balloo - Remove Active');
 
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`,
+`event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`,
+`action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`,
+`target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+--
+(2695, 0, 0, 0, 20, 0, 100, 0, 637, 0, 0, 0, 0, 0, 80, 2695001, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                 'Sara Balloo - On Quest 637 Rewarded - Run Script'),
+--
+(2695001, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                       'Sara Balloo - Set Active'),
+(2695001, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                       'Sara Balloo - Remove Questgiver Flag'),
+(2695001, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                        'Sara Balloo - Say Line 0'),
+(2695001, 9, 3, 0, 0, 0, 100, 0, 6000, 6000, 0, 0, 0, 0, 5, 15, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                 'Sara Balloo - Emote Roar'),
+(2695001, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                        'Sara Balloo - Say Line 1'),
+(2695001, 9, 5, 0, 0, 0, 100, 0, 4000, 4000, 0, 0, 0, 0, 5, 18, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                 'Sara Balloo - Emote Cry'),
+(2695001, 9, 6, 0, 0, 0, 100, 0, 5000, 5000, 0, 0, 0, 0, 5, 20, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                 'Sara Balloo - Emote Beg'),
+(2695001, 9, 7, 0, 0, 0, 100, 0, 5000, 5000, 0, 0, 0, 0, 82, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                 'Sara Balloo - Add Questgiver Flag'),
+(2695001, 9, 8, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                       'Sara Balloo - Remove Active');
 
 -- Tymor (8507) quest 3449 accept
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 8507;
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 8507;
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(8507, 0, 0, 0, 19, 0, 100, 0, 3449, 0, 0, 0, 0, 0, 80, 8507001, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tymor - On Quest 3449 Accepted - Run Script');
 DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` = 8507001;
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+
 -- One row, not two: CreatureTextMgr::SendChat fires the row's Emote immediately before the
 -- chat packet, so the shout and the line go out together instead of the line clipping it.
-(8507001, 9, 0, 0, 0, 0, 100, 0, 500, 500, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tymor - Say Line 0 (emote 22 rides on the text row)');
-
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`,
+`event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`,
+`action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`,
+`target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+--
+(8507, 0, 0, 0, 19, 0, 100, 0, 3449, 0, 0, 0, 0, 0, 80, 8507001, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                'Tymor - On Quest 3449 Accepted - Run Script'),
+--
+(8507001, 9, 0, 0, 0, 0, 100, 0, 500, 500, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                    'Tymor - Say Line 0 (emote 22 rides on the text row)');
 
 -- Muren Stormpike (6114) quest 1680 accept
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 6114;
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 6114;
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(6114, 0, 0, 1, 19, 0, 100, 0, 1680, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 'Muren Stormpike - On Quest 1680 Accepted - Face Player'),
-(6114, 0, 1, 2, 61, 0, 100, 0,    0, 0, 0, 0, 0, 0,  5, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Muren Stormpike - Link - Emote Wave'),
-(6114, 0, 2, 3, 61, 0, 100, 0,    0, 0, 0, 0, 0, 0,  1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Muren Stormpike - Link - Say Line 0'),
-(6114, 0, 3, 0, 61, 0, 100, 0,    0, 0, 0, 0, 0, 0, 80, 6114001, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Muren Stormpike - Link - Run Script (turn back)');
 DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` = 6114001;
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(6114001, 9, 0, 0, 0, 0, 100, 0, 4000, 4000, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0.84, 'Muren Stormpike - Turn Back To Post');
+
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`,
+`event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`,
+`action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`,
+`target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+--
+(6114, 0, 0, 1, 19, 0, 100, 0, 1680, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0,                      'Muren Stormpike - On Quest 1680 Accepted - Face Player'),
+(6114, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0,  5, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                         'Muren Stormpike - Link - Emote Wave'),
+(6114, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0,  1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                         'Muren Stormpike - Link - Say Line 0'),
+(6114, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 80, 6114001, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                   'Muren Stormpike - Link - Run Script (turn back)'),
+--
+(6114001, 9, 0, 0, 0, 0, 100, 0, 4000, 4000, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0.84,              'Muren Stormpike - Turn Back To Post');
 
 -- Tormus Deepforge (6031) quest 1681 - walks to The Great Anvil, works, walks back, reports.
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 6031;
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 6031;
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(6031, 0, 0, 1, 20, 0, 100, 0, 1681, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tormus Deepforge - On Quest 1681 Rewarded - Walk, do not run'),
-(6031, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 64, 1, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 'Tormus Deepforge - Link - Remember the player'),
-(6031, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tormus Deepforge - Link - Say Line 0 (begins to work)'),
-(6031, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 601, 0, 0, 0, 0, 0, 8, 0, 0, 0, -4798.0127, -1105.1676, 499.6052, 0, 'Tormus Deepforge - Link - Walk To The Great Anvil'),
-(6031, 0, 4, 0, 34, 0, 100, 0, 8, 601, 0, 0, 0, 0, 80, 6031001, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tormus Deepforge - On Reaching The Anvil - Run Script'),
-(6031, 0, 5, 0, 34, 0, 100, 0, 8, 602, 0, 0, 0, 0, 80, 6031002, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tormus Deepforge - On Returning Home - Run Script');
 DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` IN (6031001, 6031002);
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(6031001, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 4.15396, 'Tormus Deepforge - Face The Anvil'),
-(6031001, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 17, 173, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tormus Deepforge - Emote State Work'),
-(6031001, 9, 2, 0, 0, 0, 100, 0, 4900, 4900, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tormus Deepforge - Clear Emote State'),
-(6031001, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 602, 0, 0, 0, 0, 0, 8, 0, 0, 0, -4793.38, -1098.17, 498.89, 0, 'Tormus Deepforge - Walk Back To His Post'),
-(6031002, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 12, 1, 0, 0, 0, 0, 0, 0, 'Tormus Deepforge - Face The Player'),
-(6031002, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 5, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tormus Deepforge - Emote Talk'),
-(6031002, 9, 2, 0, 0, 0, 100, 0, 100, 100, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tormus Deepforge - Say Line 1 (I am finished)'),
-(6031002, 9, 3, 0, 0, 0, 100, 0, 3900, 3900, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 4.60767, 'Tormus Deepforge - Resume His Usual Facing');
 
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`,
+`event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`,
+`action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`,
+`target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+--
+(6031, 0, 0, 1, 20, 0, 100, 0, 1681, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                      'Tormus Deepforge - On Quest 1681 Rewarded - Walk, do not run'),
+(6031, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 64, 1, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0,                         'Tormus Deepforge - Link - Remember the player'),
+(6031, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                          'Tormus Deepforge - Link - Say Line 0 (begins to work)'),
+(6031, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 601, 0,0,0,0,0, 8, 0,0,0, -4798.0127, -1105.1676, 499.6052, 0,    'Tormus Deepforge - Link - Walk To The Great Anvil'),
+(6031, 0, 4, 0, 34, 0, 100, 0, 8, 601, 0, 0, 0, 0, 80, 6031001, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                 'Tormus Deepforge - On Reaching The Anvil - Run Script'),
+(6031, 0, 5, 0, 34, 0, 100, 0, 8, 602, 0, 0, 0, 0, 80, 6031002, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                 'Tormus Deepforge - On Returning Home - Run Script'),
+--
+(6031001, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 4.15396,                 'Tormus Deepforge - Face The Anvil'),
+(6031001, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 17, 173, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                     'Tormus Deepforge - Emote State Work'),
+(6031001, 9, 2, 0, 0, 0, 100, 0, 4900, 4900, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                 'Tormus Deepforge - Clear Emote State'),
+(6031001, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 602, 0, 0, 0, 0, 0, 8, 0, 0, 0, -4793.38, -1098.17, 498.89, 0,  'Tormus Deepforge - Walk Back To His Post'),
+(6031002, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 12, 1, 0, 0, 0, 0, 0, 0,                      'Tormus Deepforge - Face The Player'),
+(6031002, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 5, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                        'Tormus Deepforge - Emote Talk'),
+(6031002, 9, 2, 0, 0, 0, 100, 0, 100, 100, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                    'Tormus Deepforge - Say Line 1 (I am finished)'),
+(6031002, 9, 3, 0, 0, 0, 100, 0, 3900, 3900, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 4.60767,           'Tormus Deepforge - Resume His Usual Facing');
 
 -- Historian Karnik (2916) quest 724
 DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` = 291600;
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(291600, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Karnik - Remove Gossip/Questgiver'),
-(291600, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 2.30863, 'Karnik - Face Hammertoe spot'),
-(291600, 9, 2, 0, 0, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 11, 4985, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Karnik - Cast Summon Hammertoe''s Spirit'),
-(291600, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 12, 2915, 3, 32000, 0, 0, 0, 8, 0, 0, 0, -4633.14, -1324.99, 503.383, 5.44702, 'Karnik - Summon Hammertoe''s Spirit (32s, outlasts the scene)'),
-(291600, 9, 4, 0, 0, 0, 100, 0, 3300, 3300, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Karnik - Say Line 2 (CMaNGOS opening, was missing)'),
-(291600, 9, 5, 0, 0, 0, 100, 0, 7000, 7000, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 19, 2915, 0, 0, 0, 0, 0, 0, 'Hammertoe''s Spirit - Say Line 0'),
-(291600, 9, 6, 0, 0, 0, 100, 0, 5000, 5000, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Karnik - Say Line 0'),
-(291600, 9, 7, 0, 0, 0, 100, 0, 5200, 5200, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 19, 2915, 0, 0, 0, 0, 0, 0, 'Hammertoe''s Spirit - Say Line 1'),
-(291600, 9, 8, 0, 0, 0, 100, 0, 7000, 7000, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Karnik - Say Line 1'),
-(291600, 9, 9, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 1.76278, 'Karnik - Restore facing'),
-(291600, 9, 10, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 82, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Karnik - Add Gossip/Questgiver');
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`,
+`event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`,
+`action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`,
+`target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+--
+(291600, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                        'Karnik - Remove Gossip/Questgiver'),
+(291600, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 2.30863,                  'Karnik - Face Hammertoe spot'),
+(291600, 9, 2, 0, 0, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 11, 4985, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,               'Karnik - Cast Summon Hammertoe''s Spirit'),
+(291600, 9, 3, 0, 0, 0, 100, 0,0,0,0,0,0,0, 12, 2915, 3, 32000, 0,0,0, 8, 0,0,0, -4633.14, -1324.99, 503.383, 5.447,   'Karnik - Summon Hammertoe''s Spirit (32s, outlasts the scene)'),
+(291600, 9, 4, 0, 0, 0, 100, 0, 3300, 3300, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                   'Karnik - Say Line 2 (CMaNGOS opening, was missing)'),
+(291600, 9, 5, 0, 0, 0, 100, 0, 7000, 7000, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 19, 2915, 0, 0, 0, 0, 0, 0,               'Hammertoe''s Spirit - Say Line 0'),
+(291600, 9, 6, 0, 0, 0, 100, 0, 5000, 5000, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                   'Karnik - Say Line 0'),
+(291600, 9, 7, 0, 0, 0, 100, 0, 5200, 5200, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 19, 2915, 0, 0, 0, 0, 0, 0,               'Hammertoe''s Spirit - Say Line 1'),
+(291600, 9, 8, 0, 0, 0, 100, 0, 7000, 7000, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                   'Karnik - Say Line 1'),
+(291600, 9, 9, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 1.76278,                  'Karnik - Restore facing'),
+(291600, 9, 10, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 82, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                       'Karnik - Add Gossip/Questgiver');
 
 -- Historian Karnik (2916) quest 3448 accept - one line, three seconds later
-DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 2916 AND `id` = 1;
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(2916, 0, 1, 0, 19, 0, 100, 0, 3448, 0, 0, 0, 0, 0, 80, 2916002, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Historian Karnik - On Quest 3448 Accepted - Run Script');
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 2916;
 DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` = 2916002;
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(2916002, 9, 0, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Historian Karnik - Say Line 3');
+
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`,
+`event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`,
+`action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`,
+`target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+--
+(2916, 0, 1, 0, 19, 0, 100, 0, 3448, 0, 0, 0, 0, 0, 80, 2916002, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                'Historian Karnik - On Quest 3448 Accepted - Run Script'),
+--
+(2916002, 9, 0, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                  'Historian Karnik - Say Line 3');
 
 -- Klockmort Spannerspan (6169) quest 1708 - steps to his bench, works, returns and reports.
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 6169;
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 6169;
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(6169, 0, 0, 1, 20, 0, 100, 0, 1708, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - On Quest 1708 Rewarded - Walk, do not run'),
-(6169, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 64, 1, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Link - Remember the player'),
-(6169, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Link - Set Active'),
-(6169, 0, 3, 4, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Link - Remove Questgiver Flag'),
-(6169, 0, 4, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 611, 0, 0, 0, 0, 0, 8, 0, 0, 0, -4814.8901, -1250.52, 501.926, 0, 'Klockmort Spannerspan - Link - Walk To The Bench'),
-(6169, 0, 5, 0, 34, 0, 100, 0, 8, 611, 0, 0, 0, 0, 80, 6169001, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - On Reaching The Bench - Run Script'),
-(6169, 0, 6, 0, 34, 0, 100, 0, 8, 612, 0, 0, 0, 0, 80, 6169002, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - On Returning Home - Run Script');
 DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` IN (6169001, 6169002);
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(6169001, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 17, 173, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Emote State Work'),
-(6169001, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Say Line 0 (begins to work)'),
-(6169001, 9, 2, 0, 0, 0, 100, 0, 6000, 6000, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Clear Emote State'),
-(6169001, 9, 3, 0, 0, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Say Line 1 (it is done)'),
-(6169001, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 5, 4, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Emote Cheer'),
-(6169001, 9, 5, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 12, 1, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Face The Player'),
-(6169001, 9, 6, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 0, 69, 612, 0, 0, 0, 0, 0, 8, 0, 0, 0, -4812.48, -1250.62, 501.947, 0, 'Klockmort Spannerspan - Walk Back To His Post'),
-(6169002, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 4.6251, 'Klockmort Spannerspan - Resume His Usual Facing'),
-(6169002, 9, 1, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 0, 82, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Add Questgiver Flag'),
-(6169002, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Klockmort Spannerspan - Clear Active');
+
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`,
+`event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`,
+`action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`,
+`target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+--
+(6169, 0, 0, 1, 20, 0, 100, 0, 1708, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                      'Klockmort Spannerspan - On Quest 1708 Rewarded - Walk, do not run'),
+(6169, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 64, 1, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0,                         'Klockmort Spannerspan - Link - Remember the player'),
+(6169, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                         'Klockmort Spannerspan - Link - Set Active'),
+(6169, 0, 3, 4, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                         'Klockmort Spannerspan - Link - Remove Questgiver Flag'),
+(6169, 0, 4, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 611, 0, 0, 0, 0, 0, 8, 0, 0, 0, -4814.89, -1250.52, 501.926, 0,   'Klockmort Spannerspan - Link - Walk To The Bench'),
+(6169, 0, 5, 0, 34, 0, 100, 0, 8, 611, 0, 0, 0, 0, 80, 6169001, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                 'Klockmort Spannerspan - On Reaching The Bench - Run Script'),
+(6169, 0, 6, 0, 34, 0, 100, 0, 8, 612, 0, 0, 0, 0, 80, 6169002, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                 'Klockmort Spannerspan - On Returning Home - Run Script'),
+--
+(6169001, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 17, 173, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                     'Klockmort Spannerspan - Emote State Work'),
+(6169001, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                        'Klockmort Spannerspan - Say Line 0 (begins to work)'),
+(6169001, 9, 2, 0, 0, 0, 100, 0, 6000, 6000, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                 'Klockmort Spannerspan - Clear Emote State'),
+(6169001, 9, 3, 0, 0, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                  'Klockmort Spannerspan - Say Line 1 (it is done)'),
+(6169001, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 5, 4, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                        'Klockmort Spannerspan - Emote Cheer'),
+(6169001, 9, 5, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 12, 1, 0, 0, 0, 0, 0, 0,                      'Klockmort Spannerspan - Face The Player'),
+(6169001, 9, 6, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 0, 69, 612, 0,0,0,0,0, 8, 0,0,0, -4812.48, -1250.62, 501.947, 0, 'Klockmort Spannerspan - Walk Back To His Post'),
+(6169002, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 4.6251,                  'Klockmort Spannerspan - Resume His Usual Facing'),
+(6169002, 9, 1, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 0, 82, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                 'Klockmort Spannerspan - Add Questgiver Flag'),
+(6169002, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                       'Klockmort Spannerspan - Clear Active');
 
 -- Talvash del Kissel (6826) quest 2204 - fetches a spell focus from his house and repairs the necklace.
-DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 6826 AND `id` IN (2, 3);
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(6826, 0, 2, 3, 20, 0, 100, 0, 2204, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - On Quest 2204 Rewarded - Walk, do not run'),
-(6826, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 80, 6826002, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Link - Run Script');
-DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 6826 AND `id` = 4;
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(6826, 0, 4, 0, 34, 0, 100, 0, 8, 623, 0, 0, 0, 0, 80, 6826003, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - On Returning Home - Restore Facing');
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 6826;
 DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` IN (6826002, 6826003);
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(6826002, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Set Active'),
-(6826002, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Remove Gossip/Questgiver'),
-(6826002, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Say Line 1'),
-(6826002, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 621, 0, 0, 0, 0, 0, 8, 0, 0, 0, -4574.79, -998.688, 503.657, 0, 'Talvash del Kissel - Walk To His House'),
-(6826002, 9, 4, 0, 0, 0, 100, 0, 10000, 10000, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Say Line 2'),
-(6826002, 9, 5, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Say Line 3'),
-(6826002, 9, 6, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 622, 0, 0, 0, 0, 0, 8, 0, 0, 0, -4580.4902, -993.985, 503.657, 0, 'Talvash del Kissel - Walk To The Bed'),
-(6826002, 9, 7, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 5, 5, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Emote Exclamation'),
-(6826002, 9, 8, 0, 0, 0, 100, 0, 5000, 5000, 0, 0, 0, 0, 5, 16, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Emote Kneel'),
-(6826002, 9, 9, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Say Line 4'),
-(6826002, 9, 10, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 623, 0, 0, 0, 0, 0, 8, 0, 0, 0, -4588.2998, -1001.21, 503.657, 0, 'Talvash del Kissel - Walk Back To His Post'),
-(6826002, 9, 11, 0, 0, 0, 100, 0, 5000, 5000, 0, 0, 0, 0, 11, 9795, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Cast Necklace Repair'),
-(6826002, 9, 12, 0, 0, 0, 100, 0, 8000, 8000, 0, 0, 0, 0, 82, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Add Gossip/Questgiver'),
-(6826002, 9, 13, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 5, 4, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Emote Cheer'),
-(6826002, 9, 14, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Clear Active'),
-(6826002, 9, 15, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 5, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Talvash del Kissel - Say Line 5'),
-(6826003, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 3.3161, 'Talvash del Kissel - Resume His Usual Facing');
+
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`,
+`event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`,
+`action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`,
+`target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+--
+(6826, 0, 1, 0, 22, 0, 100, 512, 264, 0, 0, 0, 0, 0, 33, 6826, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0,                  'Talvash del Kissel - On train emote - Give kill credit'),
+(6826, 0, 2, 3, 20, 0, 100, 0, 2204, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                      'Talvash del Kissel - On Quest 2204 Rewarded - Walk, do not run'),
+(6826, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 80, 6826002, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                   'Talvash del Kissel - Link - Run Script'),
+(6826, 0, 4, 0, 34, 0, 100, 0, 8, 623, 0, 0, 0, 0, 80, 6826003, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                 'Talvash del Kissel - On Returning Home - Restore Facing'),
+--
+(6826002, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                       'Talvash del Kissel - Set Active'),
+(6826002, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                       'Talvash del Kissel - Remove Gossip/Questgiver'),
+(6826002, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                        'Talvash del Kissel - Say Line 1'),
+(6826002, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 621, 0, 0, 0, 0, 0, 8, 0,0,0, -4574.79, -998.688, 503.657, 0,   'Talvash del Kissel - Walk To His House'),
+(6826002, 9, 4, 0, 0, 0, 100, 0, 10000, 10000, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                'Talvash del Kissel - Say Line 2'),
+(6826002, 9, 5, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                  'Talvash del Kissel - Say Line 3'),
+(6826002, 9, 6, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 622, 0, 0, 0, 0, 0, 8, 0,0,0, -4580.49, -993.985, 503.657, 0,   'Talvash del Kissel - Walk To The Bed'),
+(6826002, 9, 7, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 5, 5, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                        'Talvash del Kissel - Emote Exclamation'),
+(6826002, 9, 8, 0, 0, 0, 100, 0, 5000, 5000, 0, 0, 0, 0, 5, 16, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                 'Talvash del Kissel - Emote Kneel'),
+(6826002, 9, 9, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                  'Talvash del Kissel - Say Line 4'),
+(6826002, 9, 10, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 623, 0, 0, 0, 0, 0, 8, 0,0,0, -4588.30, -1001.21, 503.657, 0,  'Talvash del Kissel - Walk Back To His Post'),
+(6826002, 9, 11, 0, 0, 0, 100, 0, 5000, 5000, 0, 0, 0, 0, 11, 9795, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,             'Talvash del Kissel - Cast Necklace Repair'),
+(6826002, 9, 12, 0, 0, 0, 100, 0, 8000, 8000, 0, 0, 0, 0, 82, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                'Talvash del Kissel - Add Gossip/Questgiver'),
+(6826002, 9, 13, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 5, 4, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                       'Talvash del Kissel - Emote Cheer'),
+(6826002, 9, 14, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                      'Talvash del Kissel - Clear Active'),
+(6826002, 9, 15, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 5, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                       'Talvash del Kissel - Say Line 5'),
+(6826003, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 3.3161,                  'Talvash del Kissel - Resume His Usual Facing');
 
 -- Laris Geardawdle (9616) quest 4512 - carries the slime sample over and reacts to it.
 DELETE FROM `creature_text` WHERE `CreatureID` = 9616;
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
 (9616, 0, 0, 'Incredible! Amazing! I don''t even know what this means!', 12, 0, 100, 0, 0, 0, 5447, 0, 'Laris Geardawdle - quest 4512');
+
 DELETE FROM `waypoints` WHERE `entry` = 96160;
 INSERT INTO `waypoints` (`entry`, `pointid`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `point_comment`) VALUES
 (96160, 1, -4691.35, -1316.52, 503.381, NULL, 1000, 'Laris Geardawdle - react'),
 (96160, 2, -4693.75, -1310.95, 503.381, NULL, 0, 'Laris Geardawdle - over'),
 (96160, 3, -4692.07, -1315.18, 503.381, NULL, 0, 'Laris Geardawdle - back'),
 (96160, 4, -4692.6, -1312.64, 503.381, 2.9321, 1000, 'Laris Geardawdle - home');
+
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 9616;
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 9616;
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(9616, 0, 0, 1, 20, 0, 100, 0, 4512, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Laris Geardawdle - On Quest 4512 Rewarded - Walk, do not run'),
-(9616, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Laris Geardawdle - Link - Set Active'),
-(9616, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Laris Geardawdle - Link - Remove Questgiver Flag'),
-(9616, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 232, 96160, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Laris Geardawdle - Link - Start Quest Path'),
-(9616, 0, 4, 0, 108, 0, 100, 0, 1, 96160, 0, 0, 0, 0, 80, 9616001, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Laris Geardawdle - On Waypoint 1 - Run Script'),
-(9616, 0, 5, 0, 108, 0, 100, 0, 4, 96160, 0, 0, 0, 0, 80, 9616002, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Laris Geardawdle - On Waypoint 4 - Run Script');
 DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` IN (9616001, 9616002);
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(9616001, 9, 0, 0, 0, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 5, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Laris Geardawdle - Emote Talk'),
-(9616001, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Laris Geardawdle - Say Line 0'),
-(9616002, 9, 0, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Laris Geardawdle - Clear Active'),
-(9616002, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 82, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Laris Geardawdle - Add Questgiver Flag');
+
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`,
+`event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`,
+`action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`,
+`target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+--
+(9616, 0, 0, 1, 20, 0, 100, 0, 4512, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                      'Laris Geardawdle - On Quest 4512 Rewarded - Walk, do not run'),
+(9616, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                         'Laris Geardawdle - Link - Set Active'),
+(9616, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                         'Laris Geardawdle - Link - Remove Questgiver Flag'),
+(9616, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 232, 96160, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                    'Laris Geardawdle - Link - Start Quest Path'),
+(9616, 0, 4, 0, 108, 0, 100, 0, 1, 96160, 0, 0, 0, 0, 80, 9616001, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,              'Laris Geardawdle - On Waypoint 1 - Run Script'),
+(9616, 0, 5, 0, 108, 0, 100, 0, 4, 96160, 0, 0, 0, 0, 80, 9616002, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,              'Laris Geardawdle - On Waypoint 4 - Run Script'),
+--
+(9616001, 9, 0, 0, 0, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 5, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                  'Laris Geardawdle - Emote Talk'),
+(9616001, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                        'Laris Geardawdle - Say Line 0'),
+(9616002, 9, 0, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                 'Laris Geardawdle - Clear Active'),
+(9616002, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 82, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                       'Laris Geardawdle - Add Questgiver Flag');
 
 -- Curator Thorius (8256) quest 3182 - carries the horn to its display and mounts it.
 DELETE FROM `gameobject` WHERE `guid` = 1471360;
-INSERT INTO `gameobject` (`guid`, `id`, `map`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`) VALUES
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, 
+`rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`) VALUES
 (1471360, 147136, 0, 1, 1, -4629.5, -1279.51, 503.381, 2.32129, 0, 0, 0.91706, 0.39875, -60, 100, 1);
+
 DELETE FROM `waypoints` WHERE `entry` = 82560;
 INSERT INTO `waypoints` (`entry`, `pointid`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `point_comment`) VALUES
 (82560, 1, -4652.28, -1278.88, 503.382, 5.3756, 1000, 'Curator Thorius - set off'),
 (82560, 2, -4631.19, -1278.02, 503.382, 5.4803, 22000, 'Curator Thorius - the display');
+
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 8256;
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 8256;
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(8256, 0, 0, 1, 20, 0, 100, 0, 3182, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - On Quest 3182 Rewarded - Walk, do not run'),
-(8256, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - Link - Set Active'),
-(8256, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - Link - Say Line 1 (just the spot for this horn)'),
-(8256, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 232, 82560, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - Link - Start Quest Path'),
-(8256, 0, 4, 0, 108, 0, 100, 0, 2, 82560, 0, 0, 0, 0, 80, 8256001, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - On Reaching The Display - Run Script');
 DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` = 8256001;
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(8256001, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - Say Line 2 (saving this spot)'),
-(8256001, 9, 1, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 17, 173, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - Emote State Work'),
-(8256001, 9, 2, 0, 0, 0, 100, 0, 10000, 10000, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - Clear Emote State'),
-(8256001, 9, 3, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - Say Line 3 (all done)'),
-(8256001, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 5, 4, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - Emote Cheer'),
-(8256001, 9, 5, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 70, 60, 0, 0, 0, 0, 0, 14, 1471360, 147136, 0, 0, 0, 0, 0, 'Curator Thorius - Reveal The Horn For 60s'),
-(8256001, 9, 6, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - Clear Active'),
-(8256001, 9, 7, 0, 0, 0, 100, 0, 8000, 8000, 0, 0, 0, 0, 232, 18870, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Curator Thorius - Resume His Ambient Patrol');
+
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`,
+`event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`,
+`action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`,
+`target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+--
+(8256, 0, 0, 1, 20, 0, 100, 0, 3182, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                      'Curator Thorius - On Quest 3182 Rewarded - Walk, do not run'),
+(8256, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                         'Curator Thorius - Link - Set Active'),
+(8256, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                          'Curator Thorius - Link - Say Line 1 (just the spot for this horn)'),
+(8256, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 232, 82560, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                    'Curator Thorius - Link - Start Quest Path'),
+(8256, 0, 4, 0, 108, 0, 100, 0, 2, 82560, 0, 0, 0, 0, 80, 8256001, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,              'Curator Thorius - On Reaching The Display - Run Script'),
+--
+(8256001, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                        'Curator Thorius - Say Line 2 (saving this spot)'),
+(8256001, 9, 1, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 17, 173, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,               'Curator Thorius - Emote State Work'),
+(8256001, 9, 2, 0, 0, 0, 100, 0, 10000, 10000, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,               'Curator Thorius - Clear Emote State'),
+(8256001, 9, 3, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                  'Curator Thorius - Say Line 3 (all done)'),
+(8256001, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 5, 4, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                        'Curator Thorius - Emote Cheer'),
+(8256001, 9, 5, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 70, 60, 0, 0, 0, 0, 0, 14, 1471360, 147136, 0, 0, 0, 0, 0,          'Curator Thorius - Reveal The Horn For 60s'),
+(8256001, 9, 6, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                       'Curator Thorius - Clear Active'),
+(8256001, 9, 7, 0, 0, 0, 100, 0, 8000, 8000, 0, 0, 0, 0, 232, 18870, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,            'Curator Thorius - Resume His Ambient Patrol');
 
 -- Grand Mason Marblesten (2790) quest 689 - carves the Memorial to Sully Balloo
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 2790;
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 2790;
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(2790, 0, 0, 1, 20, 0, 100, 0, 689, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - On Quest 689 Rewarded - Walk, do not run'),
-(2790, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Link - Clear Emote State'),
-(2790, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Link - Set Active'),
-(2790, 0, 3, 4, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Link - Remove Questgiver Flag'),
-(2790, 0, 4, 5, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Link - Say Line 0 (get to work)'),
-(2790, 0, 5, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 232, 27901, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Link - Start Quest Path'),
-(2790, 0, 6, 0, 108, 0, 100, 0, 6, 27901, 0, 0, 0, 0, 80, 2790001, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - On Reaching The Memorial - Run Script'),
-(2790, 0, 7, 0, 108, 0, 100, 0, 11, 27901, 0, 0, 0, 0, 80, 2790002, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - On Returning To His Post - Run Script');
+DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` IN (2790001, 2790002);
 
--- Grand Mason Marblesten - the work scene at the memorial (node 6 of quest path 27901) and the
--- restoration of his ambient behaviour afterwards.
-DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryorguid` IN (2790001, 2790002, 2790003);
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(2790001, 9, 0, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 17, 233, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Emote State Work Mining'),
-(2790001, 9, 1, 0, 0, 0, 100, 0, 5950, 5950, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Stop Working'),
-(2790001, 9, 2, 0, 0, 0, 100, 0, 50, 50, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 14, 821, 139852, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Reveal The Memorial'),
-(2790001, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Say Line 1 (there you have it)'),
-(2790001, 9, 4, 0, 0, 0, 100, 0, 400, 400, 0, 0, 0, 0, 5, 25, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Point At It (after the line, or the talk animation eats it)'),
-(2790001, 9, 5, 0, 0, 0, 100, 0, 5600, 5600, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 1.26, 'Grand Mason Marblesten - Turn Around (away from the memorial)'),
-(2790001, 9, 6, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Say Line 2 (guards will be along)'),
-(2790001, 9, 7, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 5, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Emote Bow'),
-(2790002, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 17, 233, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Restore His Working Animation (addon emote 233)'),
-(2790002, 9, 1, 0, 0, 0, 100, 0, 500, 500, 0, 0, 0, 0, 232, 27900, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Resume His Ambient Path (repeating)'),
-(2790002, 9, 2, 0, 0, 0, 100, 0, 10, 10, 0, 0, 0, 0, 82, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Add Questgiver Flag'),
-(2790002, 9, 3, 0, 0, 0, 100, 0, 5, 5, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Grand Mason Marblesten - Clear Active');
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`,
+`event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`,
+`action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`,
+`target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+--
+(2790, 0, 0, 1, 20, 0, 100, 0, 689, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                       'Grand Mason Marblesten - On Quest 689 Rewarded - Walk, do not run'),
+(2790, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                         'Grand Mason Marblesten - Link - Clear Emote State'),
+(2790, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                         'Grand Mason Marblesten - Link - Set Active'),
+(2790, 0, 3, 4, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                         'Grand Mason Marblesten - Link - Remove Questgiver Flag'),
+(2790, 0, 4, 5, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                          'Grand Mason Marblesten - Link - Say Line 0 (get to work)'),
+(2790, 0, 5, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 232, 27901, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                    'Grand Mason Marblesten - Link - Start Quest Path'),
+(2790, 0, 6, 0, 108, 0, 100, 0, 6, 27901, 0, 0, 0, 0, 80, 2790001, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,              'Grand Mason Marblesten - On Reaching The Memorial - Run Script'),
+(2790, 0, 7, 0, 108, 0, 100, 0, 11, 27901, 0, 0, 0, 0, 80, 2790002, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,             'Grand Mason Marblesten - On Returning To His Post - Run Script'),
+--
+(2790001, 9, 0, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 17, 233, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,               'Grand Mason Marblesten - Emote State Work Mining'),
+(2790001, 9, 1, 0, 0, 0, 100, 0, 5950, 5950, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                 'Grand Mason Marblesten - Stop Working'),
+(2790001, 9, 2, 0, 0, 0, 100, 0, 50, 50, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 14, 821, 139852, 0, 0, 0, 0, 0,              'Grand Mason Marblesten - Reveal The Memorial'),
+(2790001, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                        'Grand Mason Marblesten - Say Line 1 (there you have it)'),
+(2790001, 9, 4, 0, 0, 0, 100, 0, 400, 400, 0, 0, 0, 0, 5, 25, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                   'Grand Mason Marblesten - Point At It (after the line, or the talk animation eats it)'),
+(2790001, 9, 5, 0, 0, 0, 100, 0, 5600, 5600, 0, 0, 0, 0, 66, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 1.26,              'Grand Mason Marblesten - Turn Around (away from the memorial)'),
+(2790001, 9, 6, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                        'Grand Mason Marblesten - Say Line 2 (guards will be along)'),
+(2790001, 9, 7, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 5, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                  'Grand Mason Marblesten - Emote Bow'),
+--
+(2790002, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 17, 233, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                     'Grand Mason Marblesten - Restore His Working Animation (addon emote 233)'),
+(2790002, 9, 1, 0, 0, 0, 100, 0, 500, 500, 0, 0, 0, 0, 232, 27900, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,              'Grand Mason Marblesten - Resume His Ambient Path (repeating)'),
+(2790002, 9, 2, 0, 0, 0, 100, 0, 10, 10, 0, 0, 0, 0, 82, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                     'Grand Mason Marblesten - Add Questgiver Flag'),
+(2790002, 9, 3, 0, 0, 0, 100, 0, 5, 5, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,                       'Grand Mason Marblesten - Clear Active');
 
--- King Magni Bronzebeard 2784
+-- King Magni Bronzebeard 2784 (The scenes themselves are C++ in zone_ironforge.cpp)
 --   683  Sara Balloo's Plea     - delay 0,    broadcast 860,   text emote (ChatTypeID 2)
 --   8484 The Brokering of Peace - delay 1000, broadcast 11308, yell (ChatTypeID 1)
---
--- The scenes themselves are C++ in zone_ironforge.cpp: Magni carries
--- `creature_template`.`ScriptName` = 'npc_king_magni_bronzebeard' and
--- `CreatureAISelector::SelectAI` tests ScriptName before AIName, so `AIName` = 'SmartAI' on this
--- entry would never run. Do NOT add one here.
-
 DELETE FROM `creature_text` WHERE `CreatureID` = 2784 AND `GroupID` = 1;
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
 (2784, 1, 0, 'Let it be known that $n - Alliance $C - has earned the undying respect of Ironforge and the Alliance as a whole.  $GHe : She; has engaged in great diplomacy with Timbermaw Hold and performed valiant actions for them on our behalf.   $GHe : She; has gone above and beyond the call of duty.  Three cheers for $n - a true hero of the Alliance!', 14, 0, 100, 5, 0, 0, 11308, 0, 'King Magni Bronzebeard - The Brokering of Peace');

--- a/src/IndividualProgression_loader.cpp
+++ b/src/IndividualProgression_loader.cpp
@@ -12,6 +12,7 @@ void AddSC_instance_stratholme_50_59_B();
 void AddSC_instance_molten_core_60_1_A();
 void AddSC_quest_jail_break_60_2();
 void AddSC_quest_the_masquerade_60_2();
+void AddSC_ipp_zone_ironforge();
 void AddSC_boss_lord_kazzak_60_2();
 void AddSC_boss_chromaggus_60_2_A();
 void AddSC_boss_drakkisath_50_59_B();
@@ -67,6 +68,7 @@ void Addmod_individual_progressionScripts()
     AddSC_instance_naxxramas();
     AddSC_quest_jail_break_60_2();
     AddSC_quest_the_masquerade_60_2();
+    AddSC_ipp_zone_ironforge();
     AddSC_boss_onyxia_40();
     AddSC_boss_lord_kazzak_60_2();
     AddSC_boss_chromaggus_60_2_A();

--- a/src/vanillaScripts/zone_ironforge.cpp
+++ b/src/vanillaScripts/zone_ironforge.cpp
@@ -1,16 +1,12 @@
-
-
 #include "CreatureAI.h"
 #include "Player.h"
 #include "QuestDef.h"
 #include "ScriptMgr.h"
 
-// Extends the core's EasternKingdoms/zone_ironforge.cpp; it does not replace it. Only two things
-// could collide: the AddSC_ symbol, and the registered ScriptName string - neither does.
-//
+// Extends the core's EasternKingdoms/zone_ironforge.cpp; it does not replace it. 
+// Only two things could collide: the AddSC_ symbol, and the registered ScriptName string - neither does.
+
 // King Magni's two quest-completion lines. They cannot be SmartAI: his ScriptName owns the AI slot,
-// and CreatureAISelector::SelectAI tests it before AIName. Reasoning in
-// modules/mod-classic-zones/docs/mangos-to-ac-mapping.md section 4a.
 enum KingMagniQuestScenes
 {
     NPC_KING_MAGNI_BRONZEBEARD      = 2784,
@@ -24,7 +20,6 @@ enum KingMagniQuestScenes
 
 // One spawn world-wide, and the player has to be standing at him to hand in.
 constexpr float MAGNI_SEARCH_RANGE = 30.0f;
-
 constexpr Milliseconds BROKERING_OF_PEACE_YELL_DELAY = 1s;
 
 class ipp_zone_ironforge_playerscript : public PlayerScript
@@ -52,9 +47,8 @@ public:
             return;
         }
 
-        // A second later he yells the player's praise to the hall. The exclamation gesture is on
-        // the creature_text row's Emote column, not here. The player is passed as chat target so
-        // the yell's $N resolves; a delayed Talk stores only the guid and re-resolves on firing.
+        // A second later he yells the player's praise to the hall. The exclamation gesture is on the creature_text row's Emote column, not here. 
+		// The player is passed as chat target so the yell's $N resolves; a delayed Talk stores only the guid and re-resolves on firing.
         magni->AI()->Talk(SAY_THE_BROKERING_OF_PEACE, player, BROKERING_OF_PEACE_YELL_DELAY);
     }
 };

--- a/src/vanillaScripts/zone_ironforge.cpp
+++ b/src/vanillaScripts/zone_ironforge.cpp
@@ -1,0 +1,65 @@
+
+
+#include "CreatureAI.h"
+#include "Player.h"
+#include "QuestDef.h"
+#include "ScriptMgr.h"
+
+// Extends the core's EasternKingdoms/zone_ironforge.cpp; it does not replace it. Only two things
+// could collide: the AddSC_ symbol, and the registered ScriptName string - neither does.
+//
+// King Magni's two quest-completion lines. They cannot be SmartAI: his ScriptName owns the AI slot,
+// and CreatureAISelector::SelectAI tests it before AIName. Reasoning in
+// modules/mod-classic-zones/docs/mangos-to-ac-mapping.md section 4a.
+enum KingMagniQuestScenes
+{
+    NPC_KING_MAGNI_BRONZEBEARD      = 2784,
+
+    QUEST_SARA_BALLOOS_PLEA         = 683,
+    QUEST_THE_BROKERING_OF_PEACE    = 8484,
+
+    SAY_SARA_BALLOOS_PLEA           = 0,    // already shipped with AzerothCore, nothing fired it
+    SAY_THE_BROKERING_OF_PEACE      = 1     // added by zone_ironforge.sql
+};
+
+// One spawn world-wide, and the player has to be standing at him to hand in.
+constexpr float MAGNI_SEARCH_RANGE = 30.0f;
+
+constexpr Milliseconds BROKERING_OF_PEACE_YELL_DELAY = 1s;
+
+class ipp_zone_ironforge_playerscript : public PlayerScript
+{
+public:
+    ipp_zone_ironforge_playerscript() : PlayerScript("ipp_zone_ironforge_playerscript", { PLAYERHOOK_ON_PLAYER_COMPLETE_QUEST }) { }
+
+    void OnPlayerCompleteQuest(Player* player, Quest const* quest) override
+    {
+        if (!player || !quest)
+            return;
+
+        uint32 questId = quest->GetQuestId();
+        if (questId != QUEST_SARA_BALLOOS_PLEA && questId != QUEST_THE_BROKERING_OF_PEACE)
+            return;
+
+        Creature* magni = player->FindNearestCreature(NPC_KING_MAGNI_BRONZEBEARD, MAGNI_SEARCH_RANGE);
+        if (!magni || !magni->AI())
+            return;
+
+        // He studies Sara Balloo's note and sighs, the moment it is handed in.
+        if (questId == QUEST_SARA_BALLOOS_PLEA)
+        {
+            magni->AI()->Talk(SAY_SARA_BALLOOS_PLEA, player);
+            return;
+        }
+
+        // A second later he yells the player's praise to the hall. The exclamation gesture is on
+        // the creature_text row's Emote column, not here. The player is passed as chat target so
+        // the yell's $N resolves; a delayed Talk stores only the guid and re-resolves on firing.
+        magni->AI()->Talk(SAY_THE_BROKERING_OF_PEACE, player, BROKERING_OF_PEACE_YELL_DELAY);
+    }
+};
+
+void AddSC_ipp_zone_ironforge()
+{
+    new ipp_zone_ironforge_playerscript();
+}


### PR DESCRIPTION
zone_ironforge.sql:

-- Myra Tyrngaarde - bread vendor lines
-- Grand Mason Marblesten - ambient route, keeps his mining emote
-- Bixi Wobblebonk - ambient route
-- Sara Balloo - quest 637 scene, paced with emotes
-- Tymor - quest 3449 accept line
-- Muren Stormpike - quest 1680 accept: turns, waves, speaks, turns back
-- Tormus Deepforge - quest 1681: walks to The Great Anvil, works, walks back, reports
-- Historian Karnik - quest 724: adds his opening line to Hammertoe and holds the summon for it
-- Klockmort Spannerspan - quest 1708: steps to his bench, works, returns and reports
-- Talvash del Kissel - quest 2204: fetches a spell focus from his house and repairs the necklace
-- Laris Geardawdle - quest 4512: carries the slime sample over and reacts to it
-- Curator Thorius - quest 3182: carries the horn to its display, mounts it, resumes his route
-- Grand Mason Marblesten - quest 689: walks down and carves the Memorial to Sully Balloo
-- King Magni Bronzebeard - his Brokering of Peace yell (quest 8484)


zone_ironforge.cpp
New file to accomodate Magni scripts that cannot be SmartAI. Complementary to the stock AC one and doesn't overwrite anything there.

--He studies Sara Balloo's note and sighs, the moment it is handed in.
--A second later he yells the player's praise to the hall

Individual_progression_loader.cpp
Added the lines for the new ironforge cpp file