### PR TITLE
solve AV archer issue

### DIFF
--- a/data/sql/world/base/av.sql
+++ b/data/sql/world/base/av.sql
@@ -3605,11 +3605,11 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (13358, 0, 0, 0, 1, 0, 100, 513, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Stormpike Bowman - Out of Combat - Disable Combat Movement (No Repeat)'),
 (13358, 0, 1, 0, 10, 0, 100, 0, 0, 80, 2300, 3900, 0, 0, 11, 22121, 64, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,         'Stormpike Bowman - Within 0-80 Range - Cast Shoot'), -- OOC
 (13358, 0, 2, 0, 0, 0, 100, 0, 0, 0, 2300, 3900, 0, 0, 11, 22121, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Stormpike Bowman - Within 0-80 Range - Cast Shoot'), -- IC
-(13358, 0, 3, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 26, 1, 0, 0, 0, 0, 0, 0, 0,                    'Stormpike Bowman - On Respawn - Despawn nearby Stormpike Bowman'),
+(13358, 0, 3, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 26, 0, 0, 0, 0, 0, 0, 0, 0,                    'Stormpike Bowman - On Respawn - Despawn nearby Stormpike Bowman'),
 (13359, 0, 0, 0, 1, 0, 100, 513, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Frostwolf Bowman - Out of Combat - Disable Combat Movement (No Repeat)'),
 (13359, 0, 1, 0, 10, 0, 100, 0, 0, 80, 2300, 3900, 1, 0, 11, 22121, 64, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,         'Frostwolf Bowman - Within 0-80 Range - Cast Shoot'), -- OOC
 (13359, 0, 2, 0, 0, 0, 100, 0, 0, 0, 2300, 3900, 0, 0, 11, 22121, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Frostwolf Bowman - Within 0-80 Range - Cast Shoot'), -- IC
-(13359, 0, 3, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 26, 1, 0, 0, 0, 0, 0, 0, 0,                    'Frostwolf Bowman - On Respawn - Despawn nearby Frostwolf Bowman'),
+(13359, 0, 3, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 26, 0, 0, 0, 0, 0, 0, 0, 0,                    'Frostwolf Bowman - On Respawn - Despawn nearby Frostwolf Bowman'),
 --
 (14282, 0, 0, 0, 25, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 8876, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Frostwolf Bloodhound - In Combat - Cast Thrash'),
 (14283, 0, 0, 0, 25, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 8876, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Stormpike Owl - In Combat - Cast Thrash'),


### PR DESCRIPTION
related to: https://github.com/Grimfeather/mod-individual-progression/pull/213 and https://github.com/Grimfeather/azerothcore-wotlk/pull/18

bunker/tower archers despawn a friendly unit already standing on their spawn location.
the issue is that AC doesn't handle the range of SMART_TARGET_CLOSEST_FRIENDLY correctly

creatures can be further than the set max range and still trigger the SAI
it seems that if either X or Y is within range it will trigger
I've reduced the range from 1 to 0.

this was an issue at Tower Point and Iceblood tower.
a frostwolf bowman had and Y coordinate within a range of 1 of the coordinates of Commander Louis Philips.
resulting in Philips getting killed when the archer spawned.

At Tower Point two archers had the same issue. they had Y coordinates within range of each other.
Even with the range setting reduced to 0 they were killing each other on spawn.
I've moved 1 of the archers just a little bit to avoid this problem. (done in the AC fork)

