### PR TITLE
Fix defending av tower or bunker- #20

### DIFF
--- a/data/sql/world/base/av.sql
+++ b/data/sql/world/base/av.sql
@@ -3605,11 +3605,9 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (13358, 0, 0, 0, 1, 0, 100, 513, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Stormpike Bowman - Out of Combat - Disable Combat Movement (No Repeat)'),
 (13358, 0, 1, 0, 10, 0, 100, 0, 0, 80, 2300, 3900, 0, 0, 11, 22121, 64, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,         'Stormpike Bowman - Within 0-80 Range - Cast Shoot'), -- OOC
 (13358, 0, 2, 0, 0, 0, 100, 0, 0, 0, 2300, 3900, 0, 0, 11, 22121, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Stormpike Bowman - Within 0-80 Range - Cast Shoot'), -- IC
-(13358, 0, 3, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 26, 0, 0, 0, 0, 0, 0, 0, 0,                    'Stormpike Bowman - On Respawn - Despawn nearby Stormpike Bowman'),
 (13359, 0, 0, 0, 1, 0, 100, 513, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                    'Frostwolf Bowman - Out of Combat - Disable Combat Movement (No Repeat)'),
 (13359, 0, 1, 0, 10, 0, 100, 0, 0, 80, 2300, 3900, 1, 0, 11, 22121, 64, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0,         'Frostwolf Bowman - Within 0-80 Range - Cast Shoot'), -- OOC
 (13359, 0, 2, 0, 0, 0, 100, 0, 0, 0, 2300, 3900, 0, 0, 11, 22121, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,           'Frostwolf Bowman - Within 0-80 Range - Cast Shoot'), -- IC
-(13359, 0, 3, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 26, 0, 0, 0, 0, 0, 0, 0, 0,                    'Frostwolf Bowman - On Respawn - Despawn nearby Frostwolf Bowman'),
 --
 (14282, 0, 0, 0, 25, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 8876, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Frostwolf Bloodhound - In Combat - Cast Thrash'),
 (14283, 0, 0, 0, 25, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 8876, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,                  'Stormpike Owl - In Combat - Cast Thrash'),


### PR DESCRIPTION
related to: https://github.com/Grimfeather/azerothcore-wotlk/pull/20

no longer trying to solve the issue with SAI
now using cpp to remove any existing archers

the issue was that a new set of archers was spawned when a tower/bunker was defended
any surviving archers from the attack were not removed.
resulting in duplicate archers

IP keeps any surviving archers while the bunker/tower is contested.
base AC doesn't have this issue because AC removes all arrchers on first flag capture. which is incorrect.
