### PR TITLE
fix Solakar Flamewreath text on spawn

### DIFF
--- a/data/sql/world/base/dungeon_blackrock_spire.sql
+++ b/data/sql/world/base/dungeon_blackrock_spire.sql
@@ -88,6 +88,10 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 -- change creature visible level to ?? (CREATURE_TYPE_FLAG_BOSS_MOB)
 UPDATE `creature_template` SET `type_flags` = type_flags|4 WHERE `entry` IN (9816, 10363, 10429, 10430);
 
+DELETE FROM `creature_text` WHERE `CreatureID` = 10264;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(10264, 0, 0, 'I am here! Now, puny little worms, you will pay for your intrusion!', 14, 0, 100, 0, 0, 0, 5547, 0, 'Solakar Flamewreath');
+
 
 /* ---- Lower Blackrock Spire ---- */
 

--- a/src/vanillaScripts/instance_blackrock_spire.cpp
+++ b/src/vanillaScripts/instance_blackrock_spire.cpp
@@ -38,6 +38,7 @@ enum EventIds
     EVENT_DARGONSPIRE_ROOM_STORE    = 1,
     EVENT_DARGONSPIRE_ROOM_CHECK    = 2,
     EVENT_SOLAKAR_WAVE              = 3,
+    EVENT_SOLAKAR_SAY_SUMMON        = 4,
 
     // Progression module
     EVENT_UBRS_DOOR_OPEN_STAGE_1    = 9,
@@ -59,7 +60,14 @@ enum Texts
 {
     SAY_NEFARIUS_REND_WIPE      = 11,
     SAY_SOLAKAR_FIRST_HATCHER   = 0,
-    SAY_SCARSHIELD_INF_WHISPER  = 0
+    SAY_SCARSHIELD_INF_WHISPER  = 0,
+    SAY_SUMMON                  = 0,
+};
+
+enum Spells
+{
+    SPELL_WAR_STOMP = 16727,
+    SPELL_HATCH_EGG = 15746
 };
 
 MinionData const minionData[] =
@@ -845,8 +853,93 @@ public:
     }
 };
 
+class boss_solakar_flamewreath_50_59_B : public CreatureScript
+{
+public:
+    boss_solakar_flamewreath_50_59_B() : CreatureScript("boss_solakar_flamewreath") {}
+
+    struct boss_solakar_flamewreath : public BossAI
+    {
+        boss_solakar_flamewreath(Creature* creature) : BossAI(creature, DATA_SOLAKAR_FLAMEWREATH) {}
+
+        uint32 resetTimer;
+
+        void Reset() override
+        {
+            _Reset();
+            resetTimer = 10000;
+        }
+
+        void InitializeAI() override
+        {
+            BossAI::InitializeAI();
+            DoZoneInCombat(nullptr, 100.0f);
+        }
+
+        void JustEngagedWith(Unit* /*who*/) override
+        {
+            _JustEngagedWith();
+
+            events.ScheduleEvent(EVENT_SOLAKAR_SAY_SUMMON, 1s);
+            events.ScheduleEvent(SPELL_WAR_STOMP, 17s, 20s);
+            resetTimer = 0;
+        }
+
+        void JustDied(Unit* /*killer*/) override
+        {
+            _JustDied();
+            instance->SetData(DATA_SOLAKAR_FLAMEWREATH, DONE);
+        }
+
+        void UpdateAI(uint32 diff) override
+        {
+            if (!UpdateVictim())
+            {
+                if (resetTimer <= diff)
+                {
+                    instance->SetData(DATA_SOLAKAR_FLAMEWREATH, FAIL);
+                    return;
+                }
+                resetTimer -= diff;
+                return;
+            }
+
+            resetTimer = 10000;
+            events.Update(diff);
+
+            if (me->HasUnitState(UNIT_STATE_CASTING))
+                return;
+
+            while (uint32 eventId = events.ExecuteEvent())
+            {
+                switch (eventId)
+                {
+                case SPELL_WAR_STOMP:
+                    DoCastVictim(SPELL_WAR_STOMP);
+                    events.ScheduleEvent(SPELL_WAR_STOMP, 17s, 20s);
+                    break;
+                case EVENT_SOLAKAR_SAY_SUMMON:
+                    Talk(SAY_SUMMON);
+                    break;
+
+                default:
+                    break;
+                }
+            }
+
+            DoMeleeAttackIfReady();
+        }
+    };
+
+CreatureAI* GetAI(Creature* creature) const override
+{
+    return new boss_solakar_flamewreath(creature);
+}
+};
+
 void AddSC_instance_blackrock_spire_50_59_B()
 {
     new instance_blackrock_spire_50_59_B();
     new at_dragonspire_hall_50_59_B();
+    new boss_solakar_flamewreath_50_59_B();
 }


### PR DESCRIPTION
he had no creature_text

his TALK is currently also in `InitializeAI() override`
it should be in `Reset() override`

https://github.com/azerothcore/azerothcore-wotlk/blob/19ca6e11284d5bd2a2c274b6e88906083504ee14/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_solakar_flamewreath.cpp#L139

I try to limit my edits to AC itself, so I'll try to do it in the IP module.


edit:
I tried placing the TALK in `Reset() override`, that didn't work.
then the boss only said the text on evade

I've also tried placing it in `JustEngagedWith(Unit* /*who*/) override`, that also didn't work.
the boss only said the line on manual spawn, not during the in game event.

So now I schedule an event for saying his line.
This does work.