### PR TITLE
Add Earthliving Weapon to optional limited spells

### DIFF
--- a/data/sql/world/base/class_trainers.sql
+++ b/data/sql/world/base/class_trainers.sql
@@ -104,14 +104,19 @@ INSERT INTO `trainer_spell` (`TrainerId`, `SpellId`, `MoneyCost`, `ReqSkillLine`
 -- Shaman
 DELETE FROM `trainer_spell` WHERE `TrainerId` = 14 AND `SpellId` IN (2645, 25357, 25361, 29228, 57994);
 INSERT INTO `trainer_spell` (`TrainerId`, `SpellId`, `MoneyCost`, `ReqSkillLine`, `ReqSkillRank`, `ReqAbility1`, `ReqAbility2`, `ReqAbility3`, `ReqLevel`, `VerifiedBuild`) VALUES
-(14,2645,2200,0,0,0,0,0,20,0), -- Ghost Wolf, level 16 -> 20
+(14,2645,2200,0,0,0,0,0,20,0),          -- Ghost Wolf, level 16 -> 20
 -- (14,24398,38000,0,0,52138,0,0,62,0), -- optional, Water Shield (Rank 7), level 62 -> 71
-(14,25357,6500,0,0,10396,0,0,61,0),  -- book, Healing Wave (Rank 10), level 60 -> 61
-(14,25361,34000,0,0,10442,0,0,61,0), -- book, Strength of Earth Totem (Rank 5), level 60 -> 61
-(14,29228,65000,0,0,10448,0,0,61,0), -- book, Flame Shock (Rank 6), level 60 -> 61
+(14,25357,6500,0,0,10396,0,0,61,0),     -- book, Healing Wave (Rank 10), level 60 -> 61
+(14,25361,34000,0,0,10442,0,0,61,0),    -- book, Strength of Earth Totem (Rank 5), level 60 -> 61
+(14,29228,65000,0,0,10448,0,0,61,0),    -- book, Flame Shock (Rank 6), level 60 -> 61
 -- (14,32593,1700,0,0,974,0,0,60,0),    -- talent, Earth Shield (Rank 2), level 60 -> 61
 -- (14,33736,79000,0,0,24398,0,0,69,0), -- optional, Water Shield (Rank 8), level 69 -> 71
 -- (14,36936,7000,0,0,0,0,0,30,0),      -- optional, Totemic Recall, level 30 -> 61
+-- (14,51730,7000,0,0,0,0,0,30,0),      -- optional, Earthliving Weapon (Rank 5), Level 30 -> 71
+-- (14,51988,12000,0,0,51730,0,0,40,0), -- optional, Earthliving Weapon (Rank 5), Level 40 -> 71
+-- (14,51991,24000,0,0,51988,0,0,50,0), -- optional, Earthliving Weapon (Rank 5), Level 50 -> 71
+-- (14,51992,34000,0,0,51991,0,0,60,0), -- optional, Earthliving Weapon (Rank 5), Level 60 -> 71
+-- (14,51993,71000,0,0,51992,0,0,70,0), -- optional, Earthliving Weapon (Rank 5), Level 70 -> 71
 -- (14,52127,2200,0,0,0,0,0,20,0),      -- optional, Water Shield (Rank 1), level 20 -> 71
 -- (14,52129,6000,0,0,52127,0,0,28,0),  -- optional, Water Shield (Rank 2), level 28 -> 71
 -- (14,52131,9000,0,0,52129,0,0,34,0),  -- optional, Water Shield (Rank 3), level 34 -> 71

--- a/optional/sql/world/zz_optional_limit_spells_to_expansion.sql
+++ b/optional/sql/world/zz_optional_limit_spells_to_expansion.sql
@@ -24,27 +24,34 @@ UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 9 AND `SpellId` =
 
 -- Shaman
 UPDATE `trainer_spell` SET `ReqLevel` = 61 WHERE `TrainerId` = 14 AND `SpellId` = 36936; -- Totemic Recall, level 30 -> 61
-UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 14 AND `SpellId` = 24398; -- Water Shield (Rank 7), level 62 -> 71
-UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 14 AND `SpellId` = 33736; -- Water Shield (Rank 8), level 69 -> 71
-UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 14 AND `SpellId` = 52127; -- Water Shield (Rank 1), level 20 -> 71
-UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 14 AND `SpellId` = 52129; -- Water Shield (Rank 2), level 28 -> 71
-UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 14 AND `SpellId` = 52131; -- Water Shield (Rank 3), level 34 -> 71
-UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 14 AND `SpellId` = 52134; -- Water Shield (Rank 4), level 41 -> 71
-UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 14 AND `SpellId` = 52136; -- Water Shield (Rank 5), level 48 -> 71
-UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 14 AND `SpellId` = 52138; -- Water Shield (Rank 6), level 55 -> 71
-UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 14 AND `SpellId` = 57994; -- Wind Shear, level 16 -> 71
-UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 14 AND `SpellId` = 66842; -- Call of the Elements, level 30 -> 71
-UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 14 AND `SpellId` = 66843; -- Call of the Ancestors, level 40 -> 71
-UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 14 AND `SpellId` = 66844; -- Call of the Spirits, level 50 -> 71
+UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 14 AND `SpellId` IN
+(24398,  -- Water Shield (Rank 7), level 62 -> 71
+ 33736,  -- Water Shield (Rank 8), level 69 -> 71
+ 51730,  -- Earthliving Weapon (Rank 1), level 30 -> 71
+ 51988,  -- Earthliving Weapon (Rank 2), level 40 -> 71
+ 51991,  -- Earthliving Weapon (Rank 3), level 50 -> 71
+ 51992,  -- Earthliving Weapon (Rank 4), level 60 -> 71
+ 51993,  -- Earthliving Weapon (Rank 5), level 70 -> 71
+ 52127,  -- Water Shield (Rank 1), level 20 -> 71
+ 52129,  -- Water Shield (Rank 2), level 28 -> 71
+ 52131,  -- Water Shield (Rank 3), level 34 -> 71
+ 52134,  -- Water Shield (Rank 4), level 41 -> 71
+ 52136,  -- Water Shield (Rank 5), level 48 -> 71
+ 52138,  -- Water Shield (Rank 6), level 55 -> 71
+ 57994,  -- Wind Shear, level 16 -> 71
+ 66842,  -- Call of the Elements, level 30 -> 71
+ 66843,  -- Call of the Ancestors, level 40 -> 71
+ 66844); -- Call of the Spirits, level 50 -> 71
 
 -- Druid
-UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 33 AND `SpellId` = 50764; -- Revive (Rank 6), level 69 -> 71
-UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 33 AND `SpellId` = 50765; -- Revive (Rank 5), level 60 -> 71
-UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 33 AND `SpellId` = 50766; -- Revive (Rank 4), level 48 -> 71
-UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 33 AND `SpellId` = 50767; -- Revive (Rank 3), level 36 -> 71
-UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 33 AND `SpellId` = 50768; -- Revive (Rank 2), level 24 -> 71
-UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 33 AND `SpellId` = 50769; -- Revive (Rank 1), level 12 -> 71
-UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 33 AND `SpellId` = 62600; -- Savage Defense, level 40 -> 71
+UPDATE `trainer_spell` SET `ReqLevel` = 71 WHERE `TrainerId` = 33 AND `SpellId` IN
+(50764,  -- Revive (Rank 6), level 69 -> 71
+ 50765,  -- Revive (Rank 5), level 60 -> 71
+ 50766,  -- Revive (Rank 4), level 48 -> 71
+ 50767,  -- Revive (Rank 3), level 36 -> 71
+ 50768,  -- Revive (Rank 2), level 24 -> 71
+ 50769,  -- Revive (Rank 1), level 12 -> 71
+ 62600); -- Savage Defense, level 40 -> 71
 
 -- remove spells from characters that had already learned them and shouldn't have them anymore
 USE acore_characters;
@@ -55,5 +62,5 @@ DELETE FROM `character_spell` WHERE `spell` = 34074 AND `guid` IN (SELECT `guid`
 DELETE FROM `character_spell` WHERE `spell` IN (34120, 56641) AND `guid` IN (SELECT `guid` FROM `characters` WHERE `class` = 3 AND `level` < 71);
 DELETE FROM `character_spell` WHERE `spell` = 51722 AND `guid` IN (SELECT `guid` FROM `characters` WHERE `class` = 4 AND `level` < 71);
 DELETE FROM `character_spell` WHERE `spell` = 36936 AND `guid` IN (SELECT `guid` FROM `characters` WHERE `class` = 7 AND `level` < 61);
-DELETE FROM `character_spell` WHERE `spell` IN (24398, 33736, 52127, 52129, 52131, 52134, 52136, 52138, 57994, 66842, 66843, 66844) AND `guid` IN (SELECT `guid` FROM `characters` WHERE `class` = 7 AND `level` < 71);
+DELETE FROM `character_spell` WHERE `spell` IN (24398, 33736, 51730, 51988, 51991, 51992, 51993, 52127, 52129, 52131, 52134, 52136, 52138, 57994, 66842, 66843, 66844) AND `guid` IN (SELECT `guid` FROM `characters` WHERE `class` = 7 AND `level` < 71);
 DELETE FROM `character_spell` WHERE `spell` IN (50764, 50765, 50766, 50767, 50768, 50769, 62600) AND `guid` IN (SELECT `guid` FROM `characters` WHERE `class` = 11 AND `level` < 71);


### PR DESCRIPTION
missed Earthliving Weapon
rank 1-5 now requires level 71 when the optional file is used.